### PR TITLE
issue fix for #39 

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -164,7 +164,7 @@ module RestClient
       log_request
 
       net.start do |http|
-        res = http.request(req, payload) { |http_response| fetch_body(http_response) }
+        res = http.request(req, payload.to_s) { |http_response| fetch_body(http_response) }
         log_response res
         process_result res, & block
       end


### PR DESCRIPTION
This is a simple fix that I made to fix issue #39. 

The problem that I had was related to a fix that right_aws implemented, monkeypatching net/http. While normal net/http would call #read on the request payload, the way right_aws overrides that is that it passes the payload in directly, which is why you get that typecast error.

I didn't write any tests for this, only testing quickly to see if it worked in my projects, which it did.
