### PR TITLE
Patch to limit the number of redirects followed

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -67,9 +67,11 @@ module RestClient
       end
       args[:url] = url
       if request
+        raise TooManyRedirects if request.max_redirects == 0
         args[:password] = request.password
         args[:user] = request.user
         args[:headers] = request.headers
+        args[:max_redirects] = request.max_redirects - 1
         # pass any cookie set in the result
         if result && result['set-cookie']
           args[:headers][:cookies] = (args[:headers][:cookies] || {}).merge(parse_cookie(result['set-cookie']))

--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -163,6 +163,10 @@ module RestClient
     end
   end
 
+  class TooManyRedirects < Exception
+    message = 'Too many redirects'
+  end
+
   # The server broke the connection prior to the request completing.  Usually
   # this means it crashed, or sometimes that your network connection was
   # severed before it could complete.

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -25,7 +25,8 @@ module RestClient
     attr_reader :method, :url, :headers, :cookies,
                 :payload, :user, :password, :timeout,
                 :open_timeout, :raw_response, :verify_ssl, :ssl_client_cert,
-                :ssl_client_key, :ssl_ca_file, :processed_headers, :args
+                :ssl_client_key, :ssl_ca_file, :max_redirects,
+                :processed_headers, :args
 
     def self.execute(args, & block)
       new(args).execute(& block)
@@ -50,6 +51,7 @@ module RestClient
       @ssl_client_cert = args[:ssl_client_cert] || nil
       @ssl_client_key = args[:ssl_client_key] || nil
       @ssl_ca_file = args[:ssl_ca_file] || nil
+      @max_redirects = args[:max_redirects] || 10
       @tf = nil # If you are a raw request, this is your tempfile
       @processed_headers = make_headers headers
       @args = args


### PR DESCRIPTION
At present RestClient will recursively continue redirects ad infinitum, which is, uhm, ungood. This little patch makes it such that it will by default just follow 10 redirects.
