### PR TITLE
Better testing on AbstractRequest#request!, fix broken/ambiguous exception invocation

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -31,7 +31,7 @@ module RestClient
 
     # Return the default behavior corresponding to the response code:
     # the response itself for code in 200..206, redirection for 301, 302 and 307 in get and head cases, redirection for 303 and an exception in other cases
-    def return! request  = nil, result = nil, & block
+    def return! request = nil, result = nil, & block
       if (200..207).include? code
         self
       elsif [301, 302, 307].include? code
@@ -47,7 +47,7 @@ module RestClient
       elsif Exceptions::EXCEPTIONS_MAP[code]
         raise Exceptions::EXCEPTIONS_MAP[code].new(self, code)
       else
-        raise RequestFailed self
+        raise RequestFailed.new(self, code)
       end
     end
 

--- a/spec/abstract_response_spec.rb
+++ b/spec/abstract_response_spec.rb
@@ -64,4 +64,22 @@ describe RestClient::AbstractResponse do
   it "can access the net http result directly" do
     @response.net_http_res.should == @net_http_res
   end
+  
+  describe "#return!" do
+    it "should return the response itself on 200-codes" do
+      @net_http_res.should_receive(:code).and_return('200')
+      @response.return!.should be_equal(@response)
+    end
+
+    it "should raise RequestFailed on unknown codes" do
+      @net_http_res.should_receive(:code).and_return('1000')
+      lambda { @response.return! }.should raise_error RestClient::RequestFailed
+    end
+    
+    it "should raise an error on a redirection after non-GET/HEAD requests" do
+      @net_http_res.should_receive(:code).and_return('301')
+      @response.args.merge(:method => :put)
+      lambda { @response.return! }.should raise_error RestClient::RequestFailed
+    end
+  end
 end


### PR DESCRIPTION
Should be pretty self explanatory.  The generic "raise" in the final else doesn't work right and causes warning or crashes in some environments (due to the ambiguity of raise vs function args).
