### PR TITLE
Fixed typo

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -47,7 +47,7 @@ module RestClient
       elsif Exceptions::EXCEPTIONS_MAP[code]
         raise Exceptions::EXCEPTIONS_MAP[code].new(self, code)
       else
-        raise RequestFailed self
+        raise RequestFailed, self
       end
     end
 


### PR DESCRIPTION
If the server returns an unknown status code, rest-client would fail with:

```
  undefined method `RequestFailed' for #<String:0x00000102bf1a50> (NoMethodError)
```

Thanks!
