### PR TITLE
Re-escape cookies on requests

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -85,7 +85,7 @@ module RestClient
 
     def make_headers user_headers
       unless @cookies.empty?
-        user_headers[:cookie] = @cookies.map { |(key, val)| "#{key.to_s}=#{CGI::escape(val)}" }.sort.join(';')
+        user_headers[:cookie] = @cookies.map { |(key, val)| "#{key.to_s}=#{CGI.escape(CGI.unescape(val))}" }.sort.join(';')
       end
       headers = stringify_headers(default_headers).merge(stringify_headers(user_headers))
       headers.merge!(@payload.headers) if @payload

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -112,7 +112,7 @@ describe RestClient::Request do
   it "correctly escapes cookies" do
     @request = RestClient::Request.new(:method => 'get', :url => 'example.com', :cookies => {:session_id => 'BAh7BzoKbG9naW4iDXJob2FkbWluOg1hcHBfbmFtZSIQYXBwbGljYXRpb24%3D%0A--03793957abf47f143eb6075703cf5649d58edfb3' })
     @request.should_receive(:default_headers).and_return({'Foo' => 'bar'})
-    @request.make_headers({}).should == { 'Foo' => 'bar', 'Cookie' => 'session_id=BAh7BzoKbG9naW4iDXJob2FkbWluOg1hcHBfbmFtZSIQYXBwbGljYXRpb24%253D%250A--03793957abf47f143eb6075703cf5649d58edfb3'}
+    @request.make_headers({}).should == { 'Foo' => 'bar', 'Cookie' => 'session_id=BAh7BzoKbG9naW4iDXJob2FkbWluOg1hcHBfbmFtZSIQYXBwbGljYXRpb24%3D%0A--03793957abf47f143eb6075703cf5649d58edfb3'}
   end
 
   it "determines the Net::HTTP class to instantiate by the method name" do


### PR DESCRIPTION
This fix is regarding https://github.com/archiloque/rest-client/issues/closed#issue/30.  I think it was possibly a typo to unescape cookies for requests?
