### PR TITLE
reset_before_execution_procs

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -157,6 +157,11 @@ module RestClient
   def self.add_before_execution_proc &proc
     @@before_execution_procs << proc
   end
+  
+  # Reset the procs to be called before each request is executed.
+  def self.reset_before_execution_procs
+    @@before_execution_procs = []
+  end
 
   def self.before_execution_procs # :nodoc:
     @@before_execution_procs


### PR DESCRIPTION
Hi there,
since RestClient uses a private class variable to store the list of procs to be executed before each request, there's no way to remove/cleanup that array. I've added a trivial method to cleanup the before_execution_procs array.

I'm using RestClient in a Rails project and before_execution_procs is very handy to sign each request with an HMAC signature, unfortunately it's not thread safe. Ideally @@before_execution_procs should become an instance variable.

best,

Federico Feroldi
