### PR TITLE
Encode Params for HTTP DELETE

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -62,7 +62,7 @@ module RestClient
 
     # Extract the query parameters for get request and append them to the url
     def process_get_params url, headers
-      if [:get, :head].include? method
+      if [:get, :head, :delete].include? method
         get_params = {}
         headers.delete_if do |key, value|
           if 'params' == key.to_s.downcase && value.is_a?(Hash)


### PR DESCRIPTION
The RFC for HTTP doesn't specify whether query parameters or a message body are supported/allowed for HTTP DELETE. The RFC essentially says this is implementation defined. It makes sense to process params as query params for an HTTP DELETE if they are specified.
