### PR TITLE
RFC6265 conformation of 'Cookie:' header

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -89,7 +89,7 @@ module RestClient
 
     def make_headers user_headers
       unless @cookies.empty?
-        user_headers[:cookie] = @cookies.map { |(key, val)| "#{key.to_s}=#{CGI::unescape(val)}" }.sort.join(';')
+        user_headers[:cookie] = @cookies.map { |(key, val)| "#{key.to_s}=#{CGI::unescape(val)}" }.sort.join('; ')
       end
       headers = stringify_headers(default_headers).merge(stringify_headers(user_headers))
       headers.merge!(@payload.headers) if @payload

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -106,7 +106,7 @@ describe RestClient::Request do
     URI.stub!(:parse).and_return(mock('uri', :user => nil, :password => nil))
     @request = RestClient::Request.new(:method => 'get', :url => 'example.com', :cookies => {:session_id => '1', :user_id => "someone" })
     @request.should_receive(:default_headers).and_return({'Foo' => 'bar'})
-    @request.make_headers({}).should == { 'Foo' => 'bar', 'Cookie' => 'session_id=1;user_id=someone'}
+    @request.make_headers({}).should == { 'Foo' => 'bar', 'Cookie' => 'session_id=1; user_id=someone'}
   end
 
   it "determines the Net::HTTP class to instantiate by the method name" do


### PR DESCRIPTION
RFC6265 requires single SP after ';' for separating cookir-pair of
'Cookie:' header. WEBrick cannot parse it.
