### PR TITLE
1.6.2 changes not present in 1.6.3

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -91,7 +91,7 @@ module RestClient
       alias :length :size
 
       def close
-        @stream.close
+        @stream.close!
       end
 
       def inspect


### PR DESCRIPTION
@archiloque

Maybe I'm missing something, but I noticed that the tempfiles created as part of Payload::Base#build_stream are still hanging around. After poking around, I saw that [this commit](https://github.com/archiloque/rest-client/commit/8d35566388ee675f75980e32b78e7506838c8a16) was supposed to have fixed it, but I think between what happened with 1.6.2, those changes were lost. I added what I needed back, but I'm afraid there are bigger issues with 1.6.3. 

Just an FYI..
