### PR TITLE
Added a section to the README on passing query parameters

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -217,6 +217,15 @@ use whatever proxy the system is configured to use:
 
   RestClient.proxy = ENV['http_proxy']
 
+== Query parameters
+
+Request objects know about query parameters and will automatically add them to
+the url for GET, HEAD and DELETE requests and escape the keys and values as 
+needed:
+
+  RestClient.get 'http://example.com/resource', :params => {:foo => 'bar', :baz => 'qux'}
+  # will GET http://example.com/resource?foo=bar&baz=qux
+
 == Cookies
 
 Request and Response objects know about HTTP cookies, and will automatically


### PR DESCRIPTION
I came across and used this gem and didn't notice it handled query parameters as it wasn't documented very clearly. I only found out it did it when I was looking at the source to commit a patch for the functionality.

I've added a small section to the readme so that it might be more obvious for other people.
