### PR TITLE
Check for existing query params on URLs when appending additional params.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,38 +13,38 @@ Jeweler::Tasks.new do |s|
   s.test_files = FileList["{spec}/**/*"]
   s.add_runtime_dependency("mime-types", ">= 1.16")
   s.add_development_dependency("webmock", ">= 0.9.1")
-  s.add_development_dependency("rspec")
+  s.add_development_dependency("rspec", ">= 2.0.0")
   s.extra_rdoc_files = [ 'README.rdoc', 'history.md']
 end
 
 ############################
 
-require 'spec/rake/spectask'
+require 'rspec/core/rake_task'
 
 desc "Run all specs"
 task :spec => ["spec:unit", "spec:integration"]
 
 desc "Run unit specs"
-Spec::Rake::SpecTask.new('spec:unit') do |t|
-  t.spec_opts = ['--colour --format progress --loadby mtime --reverse']
-  t.spec_files = FileList['spec/*_spec.rb']
+RSpec::Core::RakeTask.new('spec:unit') do |t|
+  t.rspec_opts = ['--colour --format progress']
+  t.pattern = 'spec/*_spec.rb'
 end
 
 desc "Run integration specs"
-Spec::Rake::SpecTask.new('spec:integration') do |t|
-  t.spec_opts = ['--colour --format progress --loadby mtime --reverse']
-  t.spec_files = FileList['spec/integration/*_spec.rb']
+RSpec::Core::RakeTask.new('spec:integration') do |t|
+  t.rspec_opts = ['--colour --format progress']
+  t.pattern = 'spec/integration/*_spec.rb'
 end
 
 desc "Print specdocs"
-Spec::Rake::SpecTask.new(:doc) do |t|
-  t.spec_opts = ["--format", "specdoc", "--dry-run"]
-  t.spec_files = FileList['spec/*_spec.rb']
+RSpec::Core::RakeTask.new(:doc) do |t|
+  t.rspec_opts = ["--format", "specdoc", "--dry-run"]
+  t.pattern = 'spec/*_spec.rb'
 end
 
 desc "Run all examples with RCov"
-Spec::Rake::SpecTask.new('rcov') do |t|
-  t.spec_files = FileList['spec/*_spec.rb']
+RSpec::Core::RakeTask.new('rcov') do |t|
+  t.pattern = 'spec/*_spec.rb'
   t.rcov = true
   t.rcov_opts = ['--exclude', 'examples']
 end

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -79,7 +79,7 @@ module RestClient
       end
       unless url_params.empty?
         query_string = url_params.collect { |k, v| "#{k.to_s}=#{CGI::escape(v.to_s)}" }.join('&')
-        url + "?#{query_string}"
+        url + (url.include?('?') ? '&' : '?') << query_string
       else
         url
       end

--- a/spec/base.rb
+++ b/spec/base.rb
@@ -5,7 +5,7 @@ end
 Encoding.default_internal = Encoding.default_external = "ASCII-8BIT" if is_ruby_19?
 
 require 'rubygems'
-require 'spec'
+require 'rspec'
 
 begin
   require "ruby-debug"

--- a/spec/request2_spec.rb
+++ b/spec/request2_spec.rb
@@ -4,13 +4,20 @@ require 'webmock/rspec'
 include WebMock
 
 describe RestClient::Request do
+  
+  context "params for GET requests" do
+    it "manage params for get requests" do
+      stub_request(:get, 'http://some/resource?a=b&c=d').with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar'}).to_return(:body => 'foo', :status => 200)
+      RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :headers => {:foo => :bar, :params => {:a => :b, 'c' => 'd'}}).body.should == 'foo'
 
-  it "manage params for get requests" do
-    stub_request(:get, 'http://some/resource?a=b&c=d').with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar'}).to_return(:body => 'foo', :status => 200)
-    RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :headers => {:foo => :bar, :params => {:a => :b, 'c' => 'd'}}).body.should == 'foo'
-
-    stub_request(:get, 'http://some/resource').with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar', 'params' => 'a'}).to_return(:body => 'foo', :status => 200)
-    RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :headers => {:foo => :bar, :params => :a}).body.should == 'foo'
+      stub_request(:get, 'http://some/resource').with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar', 'params' => 'a'}).to_return(:body => 'foo', :status => 200)
+      RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :headers => {:foo => :bar, :params => :a}).body.should == 'foo'
+    end
+    
+    it "detects an existing query string and appends :params to the url correctly" do
+      stub_request(:get, 'http://some/resource?a=b&c=d').with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).to_return(:body => 'foo', :status => 200)
+      RestClient::Request.execute(:url => 'http://some/resource?a=b', :method => :get, :headers => {:params => {:c => :d}})
+    end
   end
 
   it "can use a block to process response" do

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -1,4 +1,4 @@
-require File.join( File.dirname(File.expand_path(__FILE__)), 'base')
+  require File.join( File.dirname(File.expand_path(__FILE__)), 'base')
 
 require 'webmock/rspec'
 include WebMock
@@ -91,8 +91,8 @@ describe RestClient::Response do
     end
 
     it "follows a redirection and keep the cookies" do
-      stub_request(:get, 'http://some/resource').to_return(:body => '', :status => 301, :headers => {'Set-Cookie' => CGI::Cookie.new('Foo', 'Bar'), 'Location' => 'http://new/resource', })
-      stub_request(:get, 'http://new/resource').with(:headers => {'Cookie' => 'Foo=Bar'}).to_return(:body => 'Qux')
+      stub_request(:get, 'http://some/resource').to_return(:body => '', :status => 301, :headers => {'Set-Cookie' => CGI::Cookie.new('Foo', 'Bar'), 'Location' => 'http://new/resource', 'User-Agent'=>'Ruby' })
+      stub_request(:get, 'http://new/resource').with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).to_return(:body => 'Qux')
       RestClient::Request.execute(:url => 'http://some/resource', :method => :get).body.should == 'Qux'
     end
 


### PR DESCRIPTION
The first commit made the specs run for me.  I have newer versions of things, it's probably not necessary and can be ignored.  The second:

https://github.com/fermion/rest-client/commit/8e826cd72688266b47d86a30bf29d125a9258b80

is the actual fix.