### PR TITLE
DELETE request with Payload

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -80,8 +80,8 @@ module RestClient
     Request.execute(:method => :put, :url => url, :payload => payload, :headers => headers, &block)
   end
 
-  def self.delete(url, headers={}, &block)
-    Request.execute(:method => :delete, :url => url, :headers => headers, &block)
+  def self.delete(url, payload, headers={}, &block)
+    Request.execute(:method => :delete, :url => url, :payload => payload, :headers => headers, &block)
   end
 
   def self.head(url, headers={}, &block)


### PR DESCRIPTION
We are attempting to use RestClient to use the Chargify.com API. One of APIs has a DELETE request with a payload. We're not aware of anything in the spec that forbids a payload for a DELETE request so we have updated the gem to support this.
