### PR TITLE
Update netrc gem to >= 0.4

### DIFF
--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -72,6 +72,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<webmock>, [">= 0.9.1"])
     s.add_dependency(%q<rspec>, [">= 0"])
   end
-  s.add_dependency(%q<netrc>, [">= 0"])
+  s.add_dependency(%q<netrc>, [">= 0.4"])
 end
 


### PR DESCRIPTION
Netrc gem now works with ruby 1.8.7.

This fixes the bug mentioned in the comments on 300ce6876715661cd32db384376f9ee33a97d237
