### PR TITLE
Remove AbstractResponse#to_i, which is too unexpected, considering:

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -51,10 +51,6 @@ module RestClient
       end
     end
 
-    def to_i
-      code
-    end
-
     def description
       "#{code} #{STATUSES[code]} | #{(headers[:content_type] || '').gsub(/;.*$/, '')} #{size} bytes\n"
     end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -13,7 +13,7 @@ describe RestClient::Response do
   it "behaves like string" do
     @response.should.to_s == 'abc'
     @response.to_str.should == 'abc'
-    @response.to_i.should == 200
+    @response.to_i.should == 0
   end
 
   it "accepts nil strings and sets it to empty for the case of HEAD" do


### PR DESCRIPTION
```ruby
require 'webmock'
require 'rest-client'
WebMock::API.stub_request(:get, 'http://host/').to_return(:body => '123')

RestClient.get('http://host/')        # "123"
RestClient.get('http://host/').to_s   # "123"
RestClient.get('http://host/').to_str # "123"
RestClient.get('http://host/').class  # String

RestClient.get('http://host/').to_i         # 200
RestClient.get('http://host/').to_s.to_i    # 200
RestClient.get('http://host/').to_str.to_i  # 200
String(RestClient.get('http://host/')).to_i # 200

RestClient.get('http://host/').dup.to_i         # 123
String.new(RestClient.get('http://host/')).to_i # 123
"#{RestClient.get('http://host/')}".to_i        # 123

RestClient.get('http://host/').clone.to_i       # 200
```