### PR TITLE
Sets the created Tempfile to binary mode during RestClient::Request#fetch_body

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -198,6 +198,7 @@ module RestClient
         # Stolen from http://www.ruby-forum.com/topic/166423
         # Kudos to _why!
         @tf = Tempfile.new("rest-client")
+        @tf.binmode
         size, total = 0, http_response.header['Content-Length'].to_i
         http_response.read_body do |chunk|
           @tf.write chunk


### PR DESCRIPTION
I was using a REST API to retrieve a large binary file, so was interested in using `raw_response` mode.

I had a character encoding exception which made it clear that attempts at translation were going on, so I set the Tempfile to binary which solved my issue.

This may not be a typical use case (perhaps people are retrieving large text-based documents that should be character-translated) but I figured I'd offer this pull request in case this seems useful.
