### PR TITLE
Implement gssapi (negotiate HTTP authentication) support

### DIFF
--- a/lib/restclient/resource.rb
+++ b/lib/restclient/resource.rb
@@ -46,9 +46,24 @@ module RestClient
       end
     end
 
+    def store_authentication reply
+      # In case we used an 'authorization' header for getting this reply,
+      # re-use it for subsequent requests. This saves one round-trip for
+      # Negotiate HTTP authentication and has no downsides.
+      headers = reply.args[:headers]
+      if headers and headers[:authorization]
+        if options[:headers]
+          options[:headers][:authorization] = headers[:authorization]
+        else
+          options[:headers] = { :authorization => headers[:authorization] }
+        end
+      end
+      return reply
+    end
+
     def get(additional_headers={}, &block)
       headers = (options[:headers] || {}).merge(additional_headers)
-      Request.execute(options.merge(
+      store_authentication Request.execute(options.merge(
               :method => :get,
               :url => url,
               :headers => headers), &(block || @block))
@@ -56,7 +71,7 @@ module RestClient
 
     def head(additional_headers={}, &block)
       headers = (options[:headers] || {}).merge(additional_headers)
-      Request.execute(options.merge(
+      store_authentication Request.execute(options.merge(
               :method => :head,
               :url => url,
               :headers => headers), &(block || @block))
@@ -64,7 +79,7 @@ module RestClient
 
     def post(payload, additional_headers={}, &block)
       headers = (options[:headers] || {}).merge(additional_headers)
-      Request.execute(options.merge(
+      store_authentication Request.execute(options.merge(
               :method => :post,
               :url => url,
               :payload => payload,
@@ -73,7 +88,7 @@ module RestClient
 
     def put(payload, additional_headers={}, &block)
       headers = (options[:headers] || {}).merge(additional_headers)
-      Request.execute(options.merge(
+      store_authentication Request.execute(options.merge(
               :method => :put,
               :url => url,
               :payload => payload,
@@ -82,7 +97,7 @@ module RestClient
 
     def patch(payload, additional_headers={}, &block)
       headers = (options[:headers] || {}).merge(additional_headers)
-      Request.execute(options.merge(
+      store_authentication Request.execute(options.merge(
               :method => :patch,
               :url => url,
               :payload => payload,
@@ -91,7 +106,7 @@ module RestClient
 
     def delete(additional_headers={}, &block)
       headers = (options[:headers] || {}).merge(additional_headers)
-      Request.execute(options.merge(
+      store_authentication Request.execute(options.merge(
               :method => :delete,
               :url => url,
               :headers => headers), &(block || @block))


### PR DESCRIPTION
This is necessary to use Kerberized servers (tested with MIT-krb5).
gssapi is not a hard new dependency, but it will be used if present.
