### PR TITLE
Disable timeouts by setting :timeout => nil or :open_timeout => nil

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -21,7 +21,7 @@ module RestClient
   # * :raw_response return a low-level RawResponse instead of a Response
   # * :max_redirects maximum number of redirections (default to 10)
   # * :verify_ssl enable ssl verification, possible values are constants from OpenSSL::SSL
-  # * :timeout and :open_timeout passing in -1 will disable the timeout by setting the corresponding net timeout values to nil
+  # * :timeout and :open_timeout are how long to wait for a response and to open a connection, in seconds. Pass nil to disable the timeout.
   # * :ssl_client_cert, :ssl_client_key, :ssl_ca_file
   class Request
 
@@ -46,8 +46,12 @@ module RestClient
       @payload = Payload.generate(args[:payload])
       @user = args[:user]
       @password = args[:password]
-      @timeout = args[:timeout]
-      @open_timeout = args[:open_timeout]
+      if args.include?(:timeout)
+        @timeout = args[:timeout]
+      end
+      if args.include?(:open_timeout)
+        @open_timeout = args[:open_timeout]
+      end
       @block_response = args[:block_response]
       @raw_response = args[:raw_response] || false
       @verify_ssl = args[:verify_ssl] || false
@@ -160,12 +164,20 @@ module RestClient
       net.cert = @ssl_client_cert if @ssl_client_cert
       net.key = @ssl_client_key if @ssl_client_key
       net.ca_file = @ssl_ca_file if @ssl_ca_file
-      net.read_timeout = @timeout if @timeout
-      net.open_timeout = @open_timeout if @open_timeout
-
-      # disable the timeout if the timeout value is -1
-      net.read_timeout = nil if @timeout == -1
-      net.out_timeout = nil if @open_timeout == -1
+      if defined? @timeout
+        if @timeout == -1
+          warn 'To disable read timeouts, please set timeout to nil instead of -1'
+          @timeout = nil
+        end
+        net.read_timeout = @timeout
+      end
+      if defined? @open_timeout
+        if @open_timeout == -1
+          warn 'To disable open timeouts, please set open_timeout to nil instead of -1'
+          @open_timeout = nil
+        end
+        net.open_timeout = @open_timeout
+      end
 
       RestClient.before_execution_procs.each do |before_proc|
         before_proc.call(req, args)

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -376,6 +376,18 @@ describe RestClient::Request do
   end
 
   describe "timeout" do
+    it "does not set timeouts if not specified" do
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload')
+      @http.stub!(:request)
+      @request.stub!(:process_result)
+      @request.stub!(:response_log)
+
+      @net.should_not_receive(:read_timeout=)
+      @net.should_not_receive(:open_timeout=)
+
+      @request.transmit(@uri, 'req', nil)
+    end
+
     it "set read_timeout" do
       @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => 123)
       @http.stub!(:request)
@@ -394,6 +406,33 @@ describe RestClient::Request do
       @request.stub!(:response_log)
 
       @net.should_receive(:open_timeout=).with(123)
+
+      @request.transmit(@uri, 'req', nil)
+    end
+
+    it "disable timeout by setting it to nil" do
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => nil, :open_timeout => nil)
+      @http.stub!(:request)
+      @request.stub!(:process_result)
+      @request.stub!(:response_log)
+
+      @net.should_receive(:read_timeout=).with(nil)
+      @net.should_receive(:open_timeout=).with(nil)
+
+      @request.transmit(@uri, 'req', nil)
+    end
+
+    it "deprecated: disable timeout by setting it to -1" do
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => -1, :open_timeout => -1)
+      @http.stub!(:request)
+      @request.stub!(:process_result)
+      @request.stub!(:response_log)
+
+      @request.should_receive(:warn)
+      @net.should_receive(:read_timeout=).with(nil)
+
+      @request.should_receive(:warn)
+      @net.should_receive(:open_timeout=).with(nil)
 
       @request.transmit(@uri, 'req', nil)
     end


### PR DESCRIPTION
Instead of -1.

Fix bug with `:open_timeout => -1` not working due to typo.

Deprecate -1 usage with a warning to switch to nil.

Add tests.

Fixes #85, #99, #120, and #127.
