### PR TITLE
Set the encoding of the response to the one given in charset header.

### DIFF
--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -14,6 +14,11 @@ module RestClient
 
     def Response.create body, net_http_res, args
       result = body || ''
+      if result.respond_to?(:force_encoding)
+        if (charset = net_http_res.type_params['charset'])
+          result.force_encoding(charset)
+        end
+      end
       result.extend Response
       result.net_http_res = net_http_res
       result.args = args


### PR DESCRIPTION
No tests, sorry. :-( I was unable to set up the necessary environment.

Anyway, the idea is to ensure that the response body has the proper encoding.