### PR TITLE
Support streaming of ActionDispatch::Http::UploadedFile

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -135,6 +135,12 @@ module RestClient
       end
 
       alias :length :size
+
+      def close
+        if @stream.respond_to?(:closed?) && @stream.respond_to?(:close)
+          super
+        end
+      end
     end
 
     class UrlEncoded < Base


### PR DESCRIPTION
Just allow IO-like objects that don't implement #closed? and #close.
