### PR TITLE
Provide functionality to specify the SSL version for the Net::HTTP connection

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -23,12 +23,14 @@ module RestClient
   # * :verify_ssl enable ssl verification, possible values are constants from OpenSSL::SSL
   # * :timeout and :open_timeout passing in -1 will disable the timeout by setting the corresponding net timeout values to nil
   # * :ssl_client_cert, :ssl_client_key, :ssl_ca_file
+  # * :ssl_version specifies the SSL version for the underlying Net::HTTP connection (defaults to 'SSLv3')
   class Request
 
     attr_reader :method, :url, :headers, :cookies,
                 :payload, :user, :password, :timeout, :max_redirects,
                 :open_timeout, :raw_response, :verify_ssl, :ssl_client_cert,
-                :ssl_client_key, :ssl_ca_file, :processed_headers, :args
+                :ssl_client_key, :ssl_ca_file, :processed_headers, :args,
+                :ssl_version
 
     def self.execute(args, & block)
       new(args).execute(& block)
@@ -54,6 +56,7 @@ module RestClient
       @ssl_client_cert = args[:ssl_client_cert] || nil
       @ssl_client_key = args[:ssl_client_key] || nil
       @ssl_ca_file = args[:ssl_ca_file] || nil
+      @ssl_version = args[:ssl_version] || 'SSLv3'
       @tf = nil # If you are a raw request, this is your tempfile
       @max_redirects = args[:max_redirects] || 10
       @processed_headers = make_headers headers
@@ -145,6 +148,7 @@ module RestClient
 
       net = net_http_class.new(uri.host, uri.port)
       net.use_ssl = uri.is_a?(URI::HTTPS)
+      net.ssl_version = @ssl_version
       if (@verify_ssl == false) || (@verify_ssl == OpenSSL::SSL::VERIFY_NONE)
         net.verify_mode = OpenSSL::SSL::VERIFY_NONE
       elsif @verify_ssl.is_a? Integer

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -207,6 +207,7 @@ describe RestClient::Request do
 
   it "transmits the request with Net::HTTP" do
     @http.should_receive(:request).with('req', 'payload')
+    @net.should_receive(:ssl_version=).with('SSLv3')
     @request.should_receive(:process_result)
     @request.transmit(@uri, 'req', 'payload')
   end
@@ -214,6 +215,7 @@ describe RestClient::Request do
   describe "payload" do
     it "sends nil payloads" do
       @http.should_receive(:request).with('req', nil)
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @request.should_receive(:process_result)
       @request.stub!(:response_log)
       @request.transmit(@uri, 'req', nil)
@@ -243,6 +245,8 @@ describe RestClient::Request do
   describe "credentials" do
     it "sets up the credentials prior to the request" do
       @http.stub!(:request)
+      @net.should_receive(:ssl_version=).with('SSLv3')
+
       @request.stub!(:process_result)
       @request.stub!(:response_log)
 
@@ -271,6 +275,7 @@ describe RestClient::Request do
 
   it "catches EOFError and shows the more informative ServerBrokeConnection" do
     @http.stub!(:request).and_raise(EOFError)
+    @net.should_receive(:ssl_version=).with('SSLv3')
     lambda { @request.transmit(@uri, 'req', nil) }.should raise_error(RestClient::ServerBrokeConnection)
   end
 
@@ -377,23 +382,25 @@ describe RestClient::Request do
 
   describe "timeout" do
     it "set read_timeout" do
-      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => 123)
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => 123, :ssl_version => 'SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
 
       @net.should_receive(:read_timeout=).with(123)
+      @net.should_receive(:ssl_version=).with('SSLv3')
 
       @request.transmit(@uri, 'req', nil)
     end
 
     it "set open_timeout" do
-      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :open_timeout => 123)
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :open_timeout => 123, :ssl_version => 'SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
 
       @net.should_receive(:open_timeout=).with(123)
+      @net.should_receive(:ssl_version=).with('SSLv3')
 
       @request.transmit(@uri, 'req', nil)
     end
@@ -403,6 +410,7 @@ describe RestClient::Request do
     it "uses SSL when the URI refers to a https address" do
       @uri.stub!(:is_a?).with(URI::HTTPS).and_return(true)
       @net.should_receive(:use_ssl=).with(true)
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -415,6 +423,7 @@ describe RestClient::Request do
 
     it "should set net.verify_mode to OpenSSL::SSL::VERIFY_NONE if verify_ssl is false" do
       @net.should_receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -422,8 +431,9 @@ describe RestClient::Request do
     end
 
     it "should not set net.verify_mode to OpenSSL::SSL::VERIFY_NONE if verify_ssl is true" do
-      @request = RestClient::Request.new(:method => :put, :url => 'https://some/resource', :payload => 'payload', :verify_ssl => true)
+      @request = RestClient::Request.new(:method => :put, :url => 'https://some/resource', :payload => 'payload', :verify_ssl => true, :ssl_version => 'SSLv3')
       @net.should_not_receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -435,9 +445,11 @@ describe RestClient::Request do
       @request = RestClient::Request.new( :method => :put,
                                           :url => 'https://some/resource',
                                           :payload => 'payload',
+                                          :ssl_version => 'SSLv3',
                                           :verify_ssl => mode )
       @net.should_receive(:verify_mode=).with(mode)
       @net.should_receive(:verify_callback=)
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -453,9 +465,11 @@ describe RestClient::Request do
               :method => :put,
               :url => 'https://some/resource',
               :payload => 'payload',
+              :ssl_version => 'SSLv3',
               :ssl_client_cert => "whatsupdoc!"
       )
       @net.should_receive(:cert=).with("whatsupdoc!")
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -466,9 +480,11 @@ describe RestClient::Request do
       @request = RestClient::Request.new(
               :method => :put,
               :url => 'https://some/resource',
+              :ssl_version => 'SSLv3',
               :payload => 'payload'
       )
       @net.should_not_receive(:cert=).with("whatsupdoc!")
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -484,9 +500,11 @@ describe RestClient::Request do
               :method => :put,
               :url => 'https://some/resource',
               :payload => 'payload',
+              :ssl_version => 'SSLv3',
               :ssl_client_key => "whatsupdoc!"
       )
       @net.should_receive(:key=).with("whatsupdoc!")
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -497,9 +515,11 @@ describe RestClient::Request do
       @request = RestClient::Request.new(
               :method => :put,
               :url => 'https://some/resource',
+              :ssl_version => 'SSLv3',
               :payload => 'payload'
       )
       @net.should_not_receive(:key=).with("whatsupdoc!")
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -515,9 +535,11 @@ describe RestClient::Request do
               :method => :put,
               :url => 'https://some/resource',
               :payload => 'payload',
+              :ssl_version => 'SSLv3',
               :ssl_ca_file => "Certificate Authority File"
       )
       @net.should_receive(:ca_file=).with("Certificate Authority File")
+      @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -528,9 +550,11 @@ describe RestClient::Request do
       @request = RestClient::Request.new(
               :method => :put,
               :url => 'https://some/resource',
+              :ssl_version => 'TSLv1',
               :payload => 'payload'
       )
       @net.should_not_receive(:ca_file=).with("Certificate Authority File")
+      @net.should_receive(:ssl_version=).with('TSLv1')
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -542,11 +566,13 @@ describe RestClient::Request do
     @request = RestClient::Request.new(
             :method => :put,
             :url => 'https://some/resource',
+            :ssl_version => 'SSLv3',
             :payload => 'payload'
     )
     net_http_res = Net::HTTPNoContent.new("", "204", "No Content")
     net_http_res.stub!(:read_body).and_return(nil)
     @http.should_receive(:request).and_return(@request.fetch_body(net_http_res))
+    @net.should_receive(:ssl_version=).with('SSLv3')
     response = @request.transmit(@uri, 'req', 'payload')
     response.should_not be_nil
     response.code.should == 204


### PR DESCRIPTION
Under some circumstances, the REST Client can fail to connect with an error message such as:

```
SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A
```

(I have observed this problem with MRI 1.9.3 p194 running on Mac OS X 10.8.1; the identical code worked flawlessly on a Fedora 17 machine.)

As explained in http://stackoverflow.com/questions/6821051/ruby-ssl-error-sslv3-alert-unexpected-message, a solution is to specify the SSL version for the Net::HTTP connection.

This patch provides a functionality to specify it via the option passed for a RestClient::Request object.
