### PR TITLE
Encoding::UndefinedConversionError when downloading an image

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -198,6 +198,7 @@ module RestClient
         # Stolen from http://www.ruby-forum.com/topic/166423
         # Kudos to _why!
         @tf = Tempfile.new("rest-client")
+        @tf.binmode
         size, total = 0, http_response.header['Content-Length'].to_i
         http_response.read_body do |chunk|
           @tf.write chunk


### PR DESCRIPTION
For instance:

```
> RestClient::Request.execute(method: :get, url: "http://lorempixel.com/200/300/", raw_response: true)
Encoding::UndefinedConversionError: "\x8B" from ASCII-8BIT to UTF-8
```

I'm using `raw_response: true` so I can get a response with a tempfile instead of keeping the data in a string.
