### PR TITLE
fix error "NoMethodError: undefined method `closed?` for Hash" with hashery

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -9,7 +9,7 @@ module RestClient
     def generate(params)
       if params.is_a?(String)
         Base.new(params)
-      elsif params.respond_to?(:read)
+      elsif params.respond_to?(:read) && params.respond_to?(:close)
         Streamed.new(params)
       elsif params
         if params.delete(:multipart) == true || has_file?(params)


### PR DESCRIPTION
see issue #141

Improved version of Pull Request #142. 

I think that
even if the params responds to "read", RestClient should check that it responds to "close" method.
