### PR TITLE
Fix typo in pull request that caused an error when trying to set the open_timeout

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -165,7 +165,7 @@ module RestClient
 
       # disable the timeout if the timeout value is -1
       net.read_timeout = nil if @timeout == -1
-      net.out_timeout = nil if @open_timeout == -1
+      net.open_timeout = nil if @open_timeout == -1
 
       RestClient.before_execution_procs.each do |before_proc|
         before_proc.call(req, args)


### PR DESCRIPTION
There was a small typo in `request.rb` that made it impossible to set an `:open_timeout` of `-1`, as it was trying to assign it to `out_timeout` instead.
