### PR TITLE
fix a typo in lib/restclient/request.rb

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -165,7 +165,7 @@ module RestClient
 
       # disable the timeout if the timeout value is -1
       net.read_timeout = nil if @timeout == -1
-      net.out_timeout = nil if @open_timeout == -1
+      net.open_timeout = nil if @open_timeout == -1
 
       RestClient.before_execution_procs.each do |before_proc|
         before_proc.call(req, args)


### PR DESCRIPTION
I noticed this while investigating timeouts in my code. This seems like a
simple typo, as there's no #out_timeout method on a Net::HTTP.
