### PR TITLE
Need a way to handle redirects to invalid URIs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source :rubygems
+
+gem 'rake'
+gem 'jeweler'
+
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,0 @@
-source :rubygems
-
-gem 'rake'
-gem 'jeweler'
-
-gemspec

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -61,7 +61,9 @@ module RestClient
 
     # Follow a redirection
     def follow_redirection request = nil, result = nil, & block
-      url = headers[:location]
+      # Unencode anything currently encoded, then reencode with any added params
+      url = URI.encode(URI.decode(headers[:location]))
+
       if url !~ /^http/
         url = URI.parse(args[:url]).merge(url).to_s
       end


### PR DESCRIPTION
In a service I am querying (TFS OData)

`/DefaultCollection/Builds?$filter=Definition+eq+'My.Defn_Site'` redirects to:

`/DefaultCollection/Builds?$filter=Definition+eq+%27My.Defn_Site%27 and StartTime ne datetime'0001-01-01T00:00:00.000'`

RestClient gives an error (URI::InvalidURIError) when trying to follow the redirect because of the unescaped spaces (I believe) in the URL. It errors here: https://github.com/archiloque/rest-client/blob/master/lib/restclient/abstract_response.rb#L66
