### PR TITLE
Now RestClient uses default ruby SSL version

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -23,7 +23,7 @@ module RestClient
   # * :verify_ssl enable ssl verification, possible values are constants from OpenSSL::SSL
   # * :timeout and :open_timeout passing in -1 will disable the timeout by setting the corresponding net timeout values to nil
   # * :ssl_client_cert, :ssl_client_key, :ssl_ca_file
-  # * :ssl_version specifies the SSL version for the underlying Net::HTTP connection (defaults to 'SSLv3')
+  # * :ssl_version specifies the SSL version for the underlying Net::HTTP connection (defaults to Ruby's settings 'SSLv23')
   class Request
 
     attr_reader :method, :url, :headers, :cookies,
@@ -56,7 +56,7 @@ module RestClient
       @ssl_client_cert = args[:ssl_client_cert] || nil
       @ssl_client_key = args[:ssl_client_key] || nil
       @ssl_ca_file = args[:ssl_ca_file] || nil
-      @ssl_version = args[:ssl_version] || 'SSLv3'
+      @ssl_version = args[:ssl_version] || OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version]
       @tf = nil # If you are a raw request, this is your tempfile
       @max_redirects = args[:max_redirects] || 10
       @processed_headers = make_headers headers

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -4,6 +4,8 @@ require 'webmock/rspec'
 include WebMock::API
 
 describe RestClient::Request do
+  let(:default_ssl_version) { OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] }
+
   before do
     @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload')
 
@@ -205,7 +207,7 @@ describe RestClient::Request do
 
   it "transmits the request with Net::HTTP" do
     @http.should_receive(:request).with('req', 'payload')
-    @net.should_receive(:ssl_version=).with('SSLv3')
+    @net.should_receive(:ssl_version=).with(default_ssl_version)
     @request.should_receive(:process_result)
     @request.transmit(@uri, 'req', 'payload')
   end
@@ -213,7 +215,7 @@ describe RestClient::Request do
   describe "payload" do
     it "sends nil payloads" do
       @http.should_receive(:request).with('req', nil)
-      @net.should_receive(:ssl_version=).with('SSLv3')
+      @net.should_receive(:ssl_version=).with(default_ssl_version)
       @request.should_receive(:process_result)
       @request.stub!(:response_log)
       @request.transmit(@uri, 'req', nil)
@@ -243,7 +245,7 @@ describe RestClient::Request do
   describe "credentials" do
     it "sets up the credentials prior to the request" do
       @http.stub!(:request)
-      @net.should_receive(:ssl_version=).with('SSLv3')
+      @net.should_receive(:ssl_version=).with(default_ssl_version)
 
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -273,7 +275,7 @@ describe RestClient::Request do
 
   it "catches EOFError and shows the more informative ServerBrokeConnection" do
     @http.stub!(:request).and_raise(EOFError)
-    @net.should_receive(:ssl_version=).with('SSLv3')
+    @net.should_receive(:ssl_version=).with(default_ssl_version)
     lambda { @request.transmit(@uri, 'req', nil) }.should raise_error(RestClient::ServerBrokeConnection)
   end
 
@@ -408,7 +410,7 @@ describe RestClient::Request do
     it "uses SSL when the URI refers to a https address" do
       @uri.stub!(:is_a?).with(URI::HTTPS).and_return(true)
       @net.should_receive(:use_ssl=).with(true)
-      @net.should_receive(:ssl_version=).with('SSLv3')
+      @net.should_receive(:ssl_version=).with(default_ssl_version)
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)
@@ -421,7 +423,7 @@ describe RestClient::Request do
 
     it "should set net.verify_mode to OpenSSL::SSL::VERIFY_NONE if verify_ssl is false" do
       @net.should_receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
-      @net.should_receive(:ssl_version=).with('SSLv3')
+      @net.should_receive(:ssl_version=).with(default_ssl_version)
       @http.stub!(:request)
       @request.stub!(:process_result)
       @request.stub!(:response_log)


### PR DESCRIPTION
Fix for issue #166 - New ssl_version default overrides expected Ruby default, violating POLA*
