### PR TITLE
Fix some exception message settings

### DIFF
--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -153,18 +153,21 @@ module RestClient
 
   # A redirect was encountered; caught by execute to retry with the new url.
   class Redirect < Exception
-
-    message = 'Redirect'
-
     attr_accessor :url
 
     def initialize(url)
       @url = url
     end
+
+    def message
+      @message ||= 'Redirect'
+    end
   end
 
   class MaxRedirectsReached < Exception	
-    message = 'Maximum number of redirect reached'	
+    def message
+      @message ||= 'Maximum number of redirect reached'
+    end
   end
 
   # The server broke the connection prior to the request completing.  Usually


### PR DESCRIPTION
Following code does not set 'FOO'.

``` ruby
class Foo
  attr_accessor :foo
  foo = 'FOO'
end

Foo.new.foo #=> nil
```
