### PR TITLE
Add Gemfile.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ rdoc
 pkg
 *.gem
 scratchpad.rb
+Gemfile.lock


### PR DESCRIPTION
It's kinda annoying that we don't want this checked in, but it
isn't ignored.
