### PR TITLE
Support for GET requests with payload.

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -65,7 +65,7 @@ require File.dirname(__FILE__) + '/restclient/net_http_ext'
 module RestClient
 
   def self.get(url, headers={}, &block)
-    Request.execute(:method => :get, :url => url, :headers => headers, &block)
+    Request.execute(:method => :get, :url => url, :payload => headers.delete(:payload), :headers => headers, &block)
   end
 
   def self.post(url, payload, headers={}, &block)

--- a/lib/restclient/resource.rb
+++ b/lib/restclient/resource.rb
@@ -47,10 +47,12 @@ module RestClient
     end
 
     def get(additional_headers={}, &block)
+      payload = additional_headers.delete(:payload)
       headers = (options[:headers] || {}).merge(additional_headers)
       Request.execute(options.merge(
               :method => :get,
               :url => url,
+              :payload => payload,
               :headers => headers), &(block || @block))
     end
 


### PR DESCRIPTION
Added support for (optionally) sending GET requests with a payload via the :payload key in additional headers; I realize it is not a header, but it seems to be the only way to do this as a conservative extension of the API. An alternative would be to add get_with_payload methods, but this seems a rather ugly solution.