### PR TITLE
Fixed parse_url

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -113,7 +113,7 @@ module RestClient
 
     def parse_url(url)
       url = "http://#{url}" unless url.match(/^http/)
-      URI.parse(url)
+      URI.parse(URI.encode(url))
     end
 
     def parse_url_with_auth(url)

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -78,6 +78,11 @@ describe RestClient::Request do
     @request.parse_url('example.com/resource')
   end
 
+  it "encode URL with spaces" do
+    URI.should_receive(:parse).with('http://example.com/resource?test=test%20with%20spaces')
+    @request.parse_url('http://example.com/resource?test=test with spaces')
+  end
+
   describe "user - password" do
     it "extracts the username and password when parsing http://user:password@example.com/" do
       URI.stub!(:parse).and_return(mock('uri', :user => 'joe', :password => 'pass1'))


### PR DESCRIPTION
When URL receive in parse_url method with spaces or other things get a raise error (Bad URL), then I do fixed with URI.encode.

