### PR TITLE
Per-request proxy configuration

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -146,6 +146,7 @@ You can:
 * specify ssl parameters
 * override cookies
 * manually handle the response (so you can operate on the response stream than reading it fully in memory)
+* bypass or use another proxy than the one configured globally (see the Proxy section below for more information)
 
 see the class' rdoc for more information.
 


### PR DESCRIPTION
One of my projects uses a couple of API client gems which are developed on top of rest-client. Everything worked great (thank you btw :-) until I needed to set a proxy for the calls going to one API but not to the others.

Since the proxy is configured via the global setting `RestClient.proxy`, I figured it would be nice to be able to set the proxy for a specific `RestClient::Request` (or bypass the globally configured proxy if necessary).

That way, I wouldn't need to resort to "dirty" tricks like this:

````ruby
old_proxy = RestClient.proxy

begin
  # Change or bypass proxy
  RestClient.proxy = new_proxy

  # Do work
ensure
  RestClient.proxy = old_proxy
end
````

I added test cases for the new parameter and updated the README accordingly.