### PR TITLE
Feature: Per-Request proxy for thread-safety

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -64,32 +64,32 @@ require File.dirname(__FILE__) + '/restclient/net_http_ext'
 #
 module RestClient
 
-  def self.get(url, headers={}, &block)
-    Request.execute(:method => :get, :url => url, :headers => headers, &block)
+  def self.get(url, headers={}, proxy=nil, &block)
+    Request.execute(:method => :get, :url => url, :headers => headers, :proxy => proxy, &block)
   end
 
-  def self.post(url, payload, headers={}, &block)
-    Request.execute(:method => :post, :url => url, :payload => payload, :headers => headers, &block)
+  def self.post(url, payload, headers={}, proxy=nil, &block)
+    Request.execute(:method => :post, :url => url, :payload => payload, :headers => headers, :proxy => proxy, &block)
   end
 
-  def self.patch(url, payload, headers={}, &block)
-    Request.execute(:method => :patch, :url => url, :payload => payload, :headers => headers, &block)
+  def self.patch(url, payload, headers={}, proxy=nil, &block)
+    Request.execute(:method => :patch, :url => url, :payload => payload, :headers => headers, :proxy => proxy, &block)
   end
 
-  def self.put(url, payload, headers={}, &block)
-    Request.execute(:method => :put, :url => url, :payload => payload, :headers => headers, &block)
+  def self.put(url, payload, headers={}, proxy=nil, &block)
+    Request.execute(:method => :put, :url => url, :payload => payload, :headers => headers, :proxy => proxy, &block)
   end
 
-  def self.delete(url, headers={}, &block)
-    Request.execute(:method => :delete, :url => url, :headers => headers, &block)
+  def self.delete(url, headers={}, proxy=nil, &block)
+    Request.execute(:method => :delete, :url => url, :headers => headers, :proxy => proxy, &block)
   end
 
-  def self.head(url, headers={}, &block)
-    Request.execute(:method => :head, :url => url, :headers => headers, &block)
+  def self.head(url, headers={}, proxy=nil, &block)
+    Request.execute(:method => :head, :url => url, :headers => headers, :proxy => proxy, &block)
   end
 
-  def self.options(url, headers={}, &block)
-    Request.execute(:method => :options, :url => url, :headers => headers, &block)
+  def self.options(url, headers={}, proxy=nil, &block)
+    Request.execute(:method => :options, :url => url, :headers => headers, :proxy => proxy, &block)
   end
 
   class << self

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -44,6 +44,7 @@ module RestClient
       else
         raise ArgumentError, "must pass :url"
       end
+      @proxy = args[:proxy]
       @cookies = @headers.delete(:cookies) || args[:cookies] || {}
       @payload = Payload.generate(args[:payload])
       @user = args[:user]
@@ -68,6 +69,10 @@ module RestClient
       transmit uri, net_http_request_class(method).new(uri.request_uri, processed_headers), payload, & block
     ensure
       payload.close if payload
+    end
+
+    def proxy
+      @proxy || RestClient.proxy
     end
 
     # Extract the query parameters and append them to the url
@@ -99,8 +104,8 @@ module RestClient
     end
 
     def net_http_class
-      if RestClient.proxy
-        proxy_uri = URI.parse(RestClient.proxy)
+      if proxy
+        proxy_uri = URI.parse(proxy)
         Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
       else
         Net::HTTP

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -4,8 +4,10 @@ require 'webmock/rspec'
 include WebMock::API
 
 describe RestClient::Request do
+  let(:request_options) do {} end
+
   before do
-    @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload')
+    @request = RestClient::Request.new({:method => :put, :url => 'http://some/resource', :payload => 'payload'}.merge(request_options))
 
     @uri = mock("uri")
     @uri.stub!(:request_uri).and_return('/resource')
@@ -309,13 +311,29 @@ describe RestClient::Request do
   end
 
   describe "proxy" do
-    it "creates a proxy class if a proxy url is given" do
-      RestClient.stub!(:proxy).and_return("http://example.com/")
-      @request.net_http_class.proxy_class?.should be_true
+    context "proxy provided" do
+      context "proxy set on global state" do
+        before { RestClient.stub!(:proxy).and_return("http://example.com/") }
+
+        it "creates a proxy class if a proxy url is given" do
+          @request.net_http_class.proxy_class?.should be_true
+        end
+      end
+
+      context "proxy option passed in during initialization" do
+        let(:request_options) do { proxy: "http://example.com" } end
+
+        it "creates a proxy class" do
+          @request.net_http_class.proxy_class?.should be_true
+        end
+      end
+
     end
 
-    it "creates a non-proxy class if a proxy url is not given" do
-      @request.net_http_class.proxy_class?.should be_false
+    context "no proxy provided" do
+      it "creates a non-proxy class if a proxy url is not given" do
+        @request.net_http_class.proxy_class?.should be_false
+      end
     end
   end
 

--- a/spec/restclient_spec.rb
+++ b/spec/restclient_spec.rb
@@ -2,38 +2,50 @@ require File.join( File.dirname(File.expand_path(__FILE__)), 'base')
 
 describe RestClient do
   describe "API" do
-    it "GET" do
-      RestClient::Request.should_receive(:execute).with(:method => :get, :url => 'http://some/resource', :headers => {})
-      RestClient.get('http://some/resource')
+    describe "GET" do
+      context "without proxy" do
+        it "should delegate to RestClient::Request with an empty proxy" do
+          RestClient::Request.should_receive(:execute).with(:method => :get, :url => 'http://some/resource', :headers => {}, proxy: nil)
+          RestClient.get('http://some/resource')
+        end
+      end
+
+      context "with proxy" do
+        it "should delegate to RestClient::Request, passing the proxy straight-through" do
+          RestClient::Request.should_receive(:execute).with(:method => :get, :url => 'http://some/resource', :headers => {}, proxy: "proxy.foo")
+          RestClient.get('http://some/resource', {}, "proxy.foo")
+        end
+      end
     end
 
+
     it "POST" do
-      RestClient::Request.should_receive(:execute).with(:method => :post, :url => 'http://some/resource', :payload => 'payload', :headers => {})
+      RestClient::Request.should_receive(:execute).with(hash_including(:method => :post, :url => 'http://some/resource', :payload => 'payload', :headers => {}))
       RestClient.post('http://some/resource', 'payload')
     end
 
     it "PUT" do
-      RestClient::Request.should_receive(:execute).with(:method => :put, :url => 'http://some/resource', :payload => 'payload', :headers => {})
+      RestClient::Request.should_receive(:execute).with(hash_including(:method => :put, :url => 'http://some/resource', :payload => 'payload', :headers => {}))
       RestClient.put('http://some/resource', 'payload')
     end
 
     it "PATCH" do
-      RestClient::Request.should_receive(:execute).with(:method => :patch, :url => 'http://some/resource', :payload => 'payload', :headers => {})
+      RestClient::Request.should_receive(:execute).with(hash_including(:method => :patch, :url => 'http://some/resource', :payload => 'payload', :headers => {}))
       RestClient.patch('http://some/resource', 'payload')
     end
 
     it "DELETE" do
-      RestClient::Request.should_receive(:execute).with(:method => :delete, :url => 'http://some/resource', :headers => {})
+      RestClient::Request.should_receive(:execute).with(hash_including(:method => :delete, :url => 'http://some/resource', :headers => {}))
       RestClient.delete('http://some/resource')
     end
 
     it "HEAD" do
-      RestClient::Request.should_receive(:execute).with(:method => :head, :url => 'http://some/resource', :headers => {})
+      RestClient::Request.should_receive(:execute).with(hash_including(:method => :head, :url => 'http://some/resource', :headers => {}))
       RestClient.head('http://some/resource')
     end
 
     it "OPTIONS" do
-      RestClient::Request.should_receive(:execute).with(:method => :options, :url => 'http://some/resource', :headers => {})
+      RestClient::Request.should_receive(:execute).with(hash_including(:method => :options, :url => 'http://some/resource', :headers => {}))
       RestClient.options('http://some/resource')
     end
   end


### PR DESCRIPTION
Hi! 

I'm building out an ActiveResource replacement called "AwesomeResource", and I needed a thread-safe way to specific a proxy with a request. With this pull request, you could now pass the proxy along with a single request: 

```ruby
RestClient.get("http://google.com", {}, "http://my.proxy")
```

Thanks!