### PR TITLE
Properly assign messages on Redirect and MaxRedirectsReached exceptions

### DIFF
--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -21,7 +21,7 @@ module RestClient
               305 => 'Use Proxy', # http/1.1
               306 => 'Switch Proxy', # no longer used
               307 => 'Temporary Redirect', # http/1.1
-              
+
               400 => 'Bad Request',
               401 => 'Unauthorized',
               402 => 'Payment Required',
@@ -46,7 +46,7 @@ module RestClient
               423 => 'Locked', #WebDAV
               424 => 'Failed Dependency', #WebDAV
               425 => 'Unordered Collection', #WebDAV
-              426 => 'Upgrade Required', 
+              426 => 'Upgrade Required',
               449 => 'Retry With', #Microsoft
               450 => 'Blocked By Windows Parental Controls', #Microsoft
 
@@ -112,7 +112,7 @@ module RestClient
     def to_s
       inspect
     end
-    
+
     def message
       @message || self.class.name
     end
@@ -154,18 +154,19 @@ module RestClient
 
   # A redirect was encountered; caught by execute to retry with the new url.
   class Redirect < Exception
-
-    message = 'Redirect'
-
     attr_accessor :url
 
     def initialize(url)
       @url = url
+      @message = 'Redirect'
     end
   end
 
-  class MaxRedirectsReached < Exception	
-    message = 'Maximum number of redirect reached'	
+  class MaxRedirectsReached < Exception
+    def initialize(message = 'Maximum number of redirects reached')
+      super nil, nil
+      self.message = message
+    end
   end
 
   # The server broke the connection prior to the request completing.  Usually

--- a/spec/exceptions_spec.rb
+++ b/spec/exceptions_spec.rb
@@ -8,14 +8,14 @@ describe RestClient::Exception do
     e = RestClient::Exception.new
     e.message.should == "RestClient::Exception"
   end
-  
+
   it "returns the 'message' that was set" do
     e = RestClient::Exception.new
     message = "An explicitly set message"
     e.message = message
     e.message.should == message
   end
-  
+
   it "sets the exception message to ErrorMessage" do
     RestClient::ResourceNotFound.new.message.should == 'Resource Not Found'
   end
@@ -27,9 +27,23 @@ describe RestClient::Exception do
 end
 
 describe RestClient::ServerBrokeConnection do
-  it "should have a default message of 'Server broke connection'" do
+  it "has a default message of 'Server broke connection'" do
     e = RestClient::ServerBrokeConnection.new
     e.message.should == 'Server broke connection'
+  end
+end
+
+describe RestClient::Redirect do
+  it "has a default message of 'Redirect'" do
+    e = RestClient::Redirect.new('target')
+    e.message.should == 'Redirect'
+  end
+end
+
+describe RestClient::MaxRedirectsReached do
+  it "has a default message of 'Maximum number of redirects reached'" do
+    e = RestClient::MaxRedirectsReached.new
+    e.message.should == 'Maximum number of redirects reached'
   end
 end
 


### PR DESCRIPTION
This eliminates Ruby warnings for assigning to unused variables and assigns the proper messages to the Redirect and MaxRedirectsReached exceptions. Before they were falling back to class names.