### PR TITLE
A possibility to specify the Array or Hash parameters for request string

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -82,7 +82,16 @@ module RestClient
         end
       end
       unless url_params.empty?
-        query_string = url_params.collect { |k, v| "#{k.to_s}=#{CGI::escape(v.to_s)}" }.join('&')
+        temp_params = url_params.collect do |key, val|
+          if val.is_a?(Hash)
+            val.collect { |k,v| "#{key.to_s}[#{k.to_s}]=#{CGI::escape(v.to_s)}" }
+          elsif val.is_a?(Array)
+            val.collect { |v| "#{key.to_s}[]=#{CGI::escape(v.to_s)}"}
+          else
+            "#{key.to_s}=#{CGI::escape(val.to_s)}"
+          end
+        end
+        query_string = temp_params.join('&')
         url + "?#{query_string}"
       else
         url


### PR DESCRIPTION
Need a request params line like this
cust_num=945263&item_nums[NC12345]=3&item_nums[NC28521]=10

A hash 
{ cust_num:945263, item_nums: {NC12345: 3, NC28521: 10 } } 
was parsed like
cust_num=945263&item_nums=%7B%3ANC12345%3D%3E3%2C+%3ANC28521%3D%3E10%7D

The same problem was with arrays