### PR TITLE
Add response body to the logs if it is not empty

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -278,7 +278,9 @@ module RestClient
     def log_response res
       if RestClient.log
         size = @raw_response ? File.size(@tf.path) : (res.body.nil? ? 0 : res.body.size)
-        RestClient.log << "# => #{res.code} #{res.class.to_s.gsub(/^Net::HTTP/, '')} | #{(res['Content-type'] || '').gsub(/;.*$/, '')} #{size} bytes\n"
+        response_to_log =  "# => #{res.code} #{res.class.to_s.gsub(/^Net::HTTP/, '')} | #{(res['Content-type'] || '').gsub(/;.*$/, '')} #{size} bytes\n"
+        response_to_log << "# => #{res.body}\n" unless res.body.nil?
+        RestClient.log << response_to_log
       end
     end
 

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -345,12 +345,12 @@ describe RestClient::Request do
       log[0].should == %Q{RestClient.get "http://url", "Accept"=>"text/plain", "Accept-Encoding"=>"gzip, deflate"\n}
     end
 
-    it "logs a response including the status code, content type, and result body size in bytes" do
+    it "logs a response including the status code, content type, result body size in bytes and the body itself" do
       log = RestClient.log = []
       res = mock('result', :code => '200', :class => Net::HTTPOK, :body => 'abcd')
       res.stub!(:[]).with('Content-type').and_return('text/html')
       @request.log_response res
-      log[0].should == "# => 200 OK | text/html 4 bytes\n"
+      log[0].should == "# => 200 OK | text/html 4 bytes\n# => abcd\n"
     end
 
     it "logs a response with a nil Content-type" do
@@ -358,7 +358,7 @@ describe RestClient::Request do
       res = mock('result', :code => '200', :class => Net::HTTPOK, :body => 'abcd')
       res.stub!(:[]).with('Content-type').and_return(nil)
       @request.log_response res
-      log[0].should == "# => 200 OK |  4 bytes\n"
+      log[0].should == "# => 200 OK |  4 bytes\n# => abcd\n"
     end
 
     it "logs a response with a nil body" do
@@ -375,7 +375,7 @@ describe RestClient::Request do
     res = mock('result', :code => '200', :class => Net::HTTPOK, :body => 'abcd')
     res.stub!(:[]).with('Content-type').and_return('text/html; charset=utf-8')
     @request.log_response res
-    log[0].should == "# => 200 OK | text/html 4 bytes\n"
+    log[0].should == "# => 200 OK | text/html 4 bytes\n# => abcd\n"
   end
 
   describe "timeout" do


### PR DESCRIPTION
I believe it's a nice feature to have the response body being logged if the response has one, we are consistently adding our own response logging for every request we use with the rest client. 
