### PR TITLE
Restore VERSION file and use it in gemspec.

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -9,6 +9,7 @@ rescue LoadError => e
   raise LoadError, "no such file to load -- net/https. Try running apt-get install libopenssl-ruby"
 end
 
+require File.dirname(__FILE__) + '/restclient/version'
 require File.dirname(__FILE__) + '/restclient/exceptions'
 require File.dirname(__FILE__) + '/restclient/request'
 require File.dirname(__FILE__) + '/restclient/abstract_response'
@@ -101,12 +102,6 @@ module RestClient
   # You can also configure logging by the environment variable RESTCLIENT_LOG.
   def self.log= log
     @@log = create_log log
-  end
-
-  def self.version
-    version_path = File.dirname(__FILE__) + "/../VERSION"
-    return File.read(version_path).chomp if File.file?(version_path)
-    "0.0.0"
   end
 
   # Create a log that respond to << like a logger

--- a/lib/restclient/version.rb
+++ b/lib/restclient/version.rb
@@ -1,0 +1,7 @@
+module RestClient
+  VERSION = '1.7.0.alpha' unless defined?(self::VERSION)
+
+  def self.version
+    VERSION
+  end
+end

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -1,8 +1,10 @@
 # -*- encoding: utf-8 -*-
 
+require File.expand_path("../lib/restclient/version", __FILE__)
+
 Gem::Specification.new do |s|
   s.name = 'rest-client'
-  s.version = '1.7.0.alpha'
+  s.version = RestClient::VERSION
   s.authors = ['REST Client Team']
   s.description = 'A simple HTTP and REST client for Ruby, inspired by the Sinatra microframework style of specifying actions: get, put, post, delete.'
   s.license = 'MIT'


### PR DESCRIPTION
After the VERSION file was removed in ca52137, `RestClient.version` would always return "0.0.0".

This should possibly be a ruby constant instead rather than read from a text file.
