### PR TITLE
For streams, actually use a stream

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -49,6 +49,8 @@ module RestClient
     end
 
     class Base
+      attr_reader :stream
+
       def initialize(params)
         build_stream(params)
       end

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -167,10 +167,11 @@ module RestClient
       log_request
 
       net.start do |http|
+        req.body_stream = payload.stream if payload
         if @block_response
-          http.request(req, payload ? payload.to_s : nil, & @block_response)
+          http.request(req, & @block_response)
         else
-          res = http.request(req, payload ? payload.to_s : nil) { |http_response| fetch_body(http_response) }
+          res = http.request(req) { |http_response| fetch_body(http_response) }
           log_response res
           process_result res, & block
         end


### PR DESCRIPTION
This avoids loading all of the data to be transmitted into memory.

If you're doing a PUT or POST of a large resource using a file handle, this will read directly from the handle rather than first schlurping everything into memory.

Since Payload creates an internal stream anyway, this simply uses that for all data types.

It seems to break some of the tests, but because the tests were using invalid requests in the first place, as far as I can tell.  I applied this to the 1.6 branch for our own use as well.
