### PR TITLE
Added the option to not follow redirects

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -67,6 +67,9 @@ module RestClient
       end
       args[:url] = url
       if request
+        unless request.follow_redirects 
+          return result 
+        end
         if request.max_redirects == 0
           raise MaxRedirectsReached
         end

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -20,6 +20,7 @@ module RestClient
   # * :block_response call the provided block with the HTTPResponse as parameter
   # * :raw_response return a low-level RawResponse instead of a Response
   # * :max_redirects maximum number of redirections (default to 10)
+  # * :follow_redirects whether to follow redirections (default to true)
   # * :verify_ssl enable ssl verification, possible values are constants from OpenSSL::SSL
   # * :timeout and :open_timeout passing in -1 will disable the timeout by setting the corresponding net timeout values to nil
   # * :ssl_client_cert, :ssl_client_key, :ssl_ca_file, :ssl_ca_path
@@ -30,7 +31,7 @@ module RestClient
                 :payload, :user, :password, :timeout, :max_redirects,
                 :open_timeout, :raw_response, :verify_ssl, :ssl_client_cert,
                 :ssl_client_key, :ssl_ca_file, :processed_headers, :args,
-                :ssl_version, :ssl_ca_path
+                :ssl_version, :ssl_ca_path, :follow_redirects
 
     def self.execute(args, & block)
       new(args).execute(& block)
@@ -60,6 +61,7 @@ module RestClient
       @ssl_version = args[:ssl_version] || 'SSLv3'
       @tf = nil # If you are a raw request, this is your tempfile
       @max_redirects = args[:max_redirects] || 10
+      @follow_redirects = args[:follow_redirects] != false
       @processed_headers = make_headers headers
       @args = args
     end

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -75,6 +75,12 @@ describe RestClient::Response do
 
   describe "redirection" do
 
+    it "doesn't follow a redirection when following is disabled" do
+      stub_request(:get, 'http://some/resource').to_return(:body => 'Foo', :status => 301, :headers => {'Location' => 'http://new/resource'})
+      stub_request(:get, 'http://new/resource').to_return(:body => 'Bar')
+      RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :follow_redirects => false).body.should eq 'Foo'
+    end
+
     it "follows a redirection when the request is a get" do
       stub_request(:get, 'http://some/resource').to_return(:body => '', :status => 301, :headers => {'Location' => 'http://new/resource'})
       stub_request(:get, 'http://new/resource').to_return(:body => 'Foo')


### PR DESCRIPTION
Added the ability to disable redirect-following. This is useful when determining e.g that an endpoint is returning the correct redirection code / headers.