### PR TITLE
Dryer flatten arguments

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -83,7 +83,9 @@ module RestClient
         end
       end
       unless url_params.empty?
-        query_string = Payload::UrlEncoded.flatten_params(url_params).map {|pair| pair.join('=')}.join('&')
+        query_string = Payload::UrlEncoded.flatten_params(url_params).
+          map { |key, value| [key, CGI::escape(value.to_s)]}.
+          map { |pair| pair.join('=') }.join('&')
         url + "?#{query_string}"
       else
         url

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -83,7 +83,7 @@ module RestClient
         end
       end
       unless url_params.empty?
-        query_string = url_params.collect { |k, v| "#{k.to_s}=#{CGI::escape(v.to_s)}" }.join('&')
+        query_string = Payload::UrlEncoded.flatten_params(url_params).map {|pair| pair.join('=')}.join('&')
         url + "?#{query_string}"
       else
         url

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -194,6 +194,11 @@ describe RestClient::Request do
         params = {:params => {'foo' => ['bar', 'baz']}}
         @request.process_url_params("http://some/resource", params).should eq 'http://some/resource?foo[]=bar&foo[]=baz'
     end
+
+    it "handles spaces in keys and values" do
+        params = {:params => {'the foo' => "the bar"}}
+        @request.process_url_params("http://some/resource", params).should eq 'http://some/resource?the%20foo=the+bar'
+    end
   end
 
   it "executes by constructing the Net::HTTP object, headers, and payload and calling transmit" do

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -189,6 +189,11 @@ describe RestClient::Request do
     it "converts header values to strings" do
       @request.make_headers('A' => 1)['A'].should eq '1'
     end
+
+    it "converts array values to strings" do
+        params = {:params => {'foo' => ['bar', 'baz']}}
+        @request.process_url_params("http://some/resource", params).should eq 'http://some/resource?foo[]=bar&foo[]=baz'
+    end
   end
 
   it "executes by constructing the Net::HTTP object, headers, and payload and calling transmit" do


### PR DESCRIPTION
The following two commits accomplish the following, respectively:

7c9d39b:
Certain utility methods in payload, when reworked as class methods, can be used in other parts of rest-client to ensure that parameters are consistently flattened into HTTP requests. By itself, this commit is functionally equivalent to its ancestor.

593cf00:
By utilizing Payload::UrlEncoded.flatten_params instead of the current ad-hoc implementation in Request#process_url_params, we're able to resolve the following issue with existing code. This allows requests to be created with arrays, using the Rails convention already adopted by Payload.rb.

https://github.com/rest-client/rest-client/issues/59