### PR TITLE
Handled flatten_params_array for empty arrays

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -83,6 +83,7 @@ module RestClient
 
       def flatten_params_array value, calculated_key
         result = []
+        result << ["#{calculated_key}[]", ""] if value == []
         value.each do |elem|
           if elem.is_a? Hash
             result += flatten_params(elem, calculated_key)

--- a/spec/unit/payload_spec.rb
+++ b/spec/unit/payload_spec.rb
@@ -21,6 +21,11 @@ describe RestClient::Payload do
           should eq "foo%20=bar"
     end
 
+    it "should properly handle empty strings" do
+      RestClient::Payload::UrlEncoded.new({'foo' => '', 'bar' => 'baz'}).to_s.
+          should eq "foo=&bar=baz"
+    end
+
     it "should properly handle hashes as parameter" do
       RestClient::Payload::UrlEncoded.new({:foo => {:bar => 'baz'}}).to_s.
           should eq "foo[bar]=baz"
@@ -55,6 +60,16 @@ describe RestClient::Payload do
           should eq "foo[]=bar"
       RestClient::Payload::UrlEncoded.new({:foo => ['bar', 'baz']}).to_s.
           should eq "foo[]=bar&foo[]=baz"
+    end
+
+    it "should properly handle empty arrays" do
+      RestClient::Payload::UrlEncoded.new({'foo' => [], 'bar' => 'baz'}).to_s.
+          should eq "foo[]=&bar=baz"
+    end
+
+    it "should properly handle empty arrays inside an array" do
+      RestClient::Payload::UrlEncoded.new({'foo' => ['qux' => [] ], 'bar' => 'baz'}).to_s.
+          should eq "foo[qux][]=&bar=baz"
     end
 
     it 'should not close if stream already closed' do


### PR DESCRIPTION
If flatten_params encounters an empty array, it skipped it. Now it behaves similar to an empty string (which works as expected). Added tests in spec illustrating the change. 

Scenario: I was working on an app where I need to return a list of selected items (among other things). If nothing is selected, rest-client skips the array giving the server the impression nothing has changed.

This patch worked for me, is there a better to handle this?