### PR TITLE
Don't use mime-types 2.0 (Ruby 1.8 support)

### DIFF
--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -59,16 +59,16 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<mime-types>, [">= 1.16"])
+      s.add_runtime_dependency(%q<mime-types>, ["~> 1.16"])
       s.add_development_dependency(%q<webmock>, [">= 0.9.1"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
     else
-      s.add_dependency(%q<mime-types>, [">= 1.16"])
+      s.add_dependency(%q<mime-types>, ["~> 1.16"])
       s.add_dependency(%q<webmock>, [">= 0.9.1"])
       s.add_dependency(%q<rspec>, [">= 0"])
     end
   else
-    s.add_dependency(%q<mime-types>, [">= 1.16"])
+    s.add_dependency(%q<mime-types>, ["~> 1.16"])
     s.add_dependency(%q<webmock>, [">= 0.9.1"])
     s.add_dependency(%q<rspec>, [">= 0"])
   end


### PR DESCRIPTION
Mime-types 2.0 breaks compatibility with Ruby 1.8, here's a suggestion to use an older version. 

The PR isn't against the right branch, as there is no branch that point to the 1.6.7 tag, but here's the idea.
