### PR TITLE
Restrict mime-types runtime dependency to < 2.0

### DIFF
--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/rest-client/rest-client'
   s.summary = 'Simple HTTP and REST client for Ruby, inspired by microframework syntax for specifying actions.'
 
-  s.add_runtime_dependency(%q<mime-types>, [">= 1.16"])
+  s.add_runtime_dependency(%q<mime-types>, ["~> 1.16"])
   s.add_development_dependency(%q<webmock>, ["~> 1.4"])
   s.add_development_dependency(%q<rspec>, ["~> 2.4"])
   s.add_dependency(%q<netrc>, ["~> 0.7.7"])


### PR DESCRIPTION
v2.0 of `mime-types` is not compatible with Ruby v1.8.7, whereas previous versions are. Restrict present rest-client to using mime-types <2.0 in order to preserve compatibility.

:rage: :rage4: 
