### PR TITLE
Adding additional proxy option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -231,9 +231,11 @@ shell or a script to replay your sequence of rest calls.
 == Proxy
 
 All calls to RestClient, including Resources, will use the proxy specified by
-RestClient.proxy:
+RestClient.proxy, and optionally by RestClient.proxy_user and RestClient.proxy_pass:
 
   RestClient.proxy = "http://proxy.example.com/"
+  RestClient.proxy_user = "proxy_user"
+  RestClient.proxy_pass = "proxy_pass"
   RestClient.get "http://some/resource"
   # => response from some/resource as proxied through proxy.example.com
 

--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -53,6 +53,11 @@ require File.dirname(__FILE__) + '/restclient/net_http_ext'
 #
 #   RestClient.proxy = "http://proxy.example.com/"
 #
+# And optionally:
+#
+#   RestClient.proxy_user = "proxy_user"
+#   RestClient.proxy_pass = "proxy_pass"
+#
 # Or inherit the proxy from the environment:
 #
 #   RestClient.proxy = ENV['http_proxy']
@@ -93,7 +98,7 @@ module RestClient
   end
 
   class << self
-    attr_accessor :proxy
+    attr_accessor :proxy, :proxy_user, :proxy_pass
   end
 
   # Setup the log for RestClient calls.

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -102,7 +102,11 @@ module RestClient
     def net_http_class
       if RestClient.proxy
         proxy_uri = URI.parse(RestClient.proxy)
-        Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+        if RestClient.proxy_user && RestClient.proxy_pass
+          Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, RestClient.proxy_user, RestClient.proxy_pass);
+        else
+          Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+        end
       else
         Net::HTTP
       end


### PR DESCRIPTION
I know there is another solution #189 or #191, by adding parameters, I think it would also be handy to have additional options, RestClient.proxy_user and RestClient.proxy_pass. You can use user/pass in existing url string, but if they include "@" or any other delimiters, it will throw parse error. This fix is minimum workaround for that issue.
