### PR TITLE
use open-uri and add no_proxy support

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -1,7 +1,6 @@
 require 'net/http'
 require 'openssl'
 require 'stringio'
-require 'uri'
 require 'open-uri'
 require 'zlib'
 

--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -2,6 +2,7 @@ require 'net/http'
 require 'openssl'
 require 'stringio'
 require 'uri'
+require 'open-uri'
 require 'zlib'
 
 require File.dirname(__FILE__) + '/restclient/version'

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -349,7 +349,7 @@ module RestClient
     def need_proxy?(uri)
       http_proxy = ENV['http_proxy']
       https_proxy = ENV['https_proxy']
-      ENV['http_proxy'] = ENV['https_proxy'] = ''
+      ENV['http_proxy'] = ENV['https_proxy'] = RestClient.proxy
       need = !uri.find_proxy.nil?
       ENV['http_proxy'] = http_proxy
       ENV['https_proxy'] = https_proxy

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -6,6 +6,7 @@ describe RestClient::Request do
 
     @uri = double("uri")
     @uri.stub(:request_uri).and_return('/resource')
+    @uri.stub(:find_proxy).and_return(nil)
     @uri.stub(:host).and_return('some')
     @uri.stub(:port).and_return(80)
 
@@ -358,6 +359,11 @@ describe RestClient::Request do
     it "creates a proxy class if a proxy url is given" do
       RestClient.stub(:proxy).and_return("http://example.com/")
       @request.net_http_class.proxy_class?.should be_true
+    end
+
+    it "creates a non-proxy class if a proxy url is given and need_proxy set to false" do
+      RestClient.stub(:proxy).and_return("http://example.com/")
+      @request.net_http_class(false).proxy_class?.should be_false
     end
 
     it "creates a non-proxy class if a proxy url is not given" do


### PR DESCRIPTION
With the proxy setting is done, all request will pass the proxy. But when I need to some internal request, it also pass the proxy, and failed.

So I add the no_proxy support, with this environment variable, I can direct connect the host with proxy setting.