### PR TITLE
Handling escaped user/pass string properly (The 2nd solution for the problem when @ in user/pass)

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -102,7 +102,7 @@ module RestClient
     def net_http_class
       if RestClient.proxy
         proxy_uri = URI.parse(RestClient.proxy)
-        Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+        Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, CGI.unescape(proxy_uri.user), CGI.unescape(proxy_uri.password))
       else
         Net::HTTP
       end

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -102,7 +102,11 @@ module RestClient
     def net_http_class
       if RestClient.proxy
         proxy_uri = URI.parse(RestClient.proxy)
-        Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, CGI.unescape(proxy_uri.user), CGI.unescape(proxy_uri.password))
+        if proxy_uri.user && proxy_uri.password
+          Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, CGI.unescape(proxy_uri.user), CGI.unescape(proxy_uri.password))
+        else
+          Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port)
+        end
       else
         Net::HTTP
       end


### PR DESCRIPTION
This is another way to handle @ in proxy user/pass.

Other than previous #245, it handles RestClient.proxy string alone, unescaping user/pass string beforehand.
Since Rubygem uses escaped user/pass string in proxy string, it would be more reasonable way.