### PR TITLE
Ensure returned mime type returned is not obsolete

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -326,7 +326,7 @@ module MIME
     # Return the first found content-type for a value considered as an extension or the value itself
     def type_for_extension ext
       candidates = @extension_index[ext]
-      candidates.empty? ? ext : candidates[0].content_type
+      candidates.empty? ? ext : candidates.last.content_type
     end
 
     class << self

--- a/spec/integration/request_spec.rb
+++ b/spec/integration/request_spec.rb
@@ -61,3 +61,13 @@ describe RestClient::Request do
     end
   end
 end
+
+describe MIME::Types do
+  describe "#type_for_extension" do
+    subject(:type_for_extension) { described_class.type_for_extension('csv') }
+
+    it "does not return an obsolete mime type" do
+      expect(type_for_extension).to eq('text/csv')
+    end
+  end
+end


### PR DESCRIPTION
The mime-types gem [sorts (via `priority_compare`)](https://github.com/halostatue/mime-types/blob/master/lib/mime/types.rb#L169) obsolete [types first](https://github.com/halostatue/mime-types/blob/master/lib/mime/type.rb#L162) in the return Array, so using the last element ensures that if an active type is present, it is returned here.

An example usage of where this showed up incorrect was the `csv` format, which incorrectly returned the obsolete value [`text/comma-separated-values`](https://github.com/halostatue/mime-types/blob/master/type-lists/text.yaml#L30).
