### PR TITLE
Adds CA certificate store support

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -30,7 +30,7 @@ module RestClient
                 :payload, :user, :password, :timeout, :max_redirects,
                 :open_timeout, :raw_response, :verify_ssl, :ssl_client_cert,
                 :ssl_client_key, :ssl_ca_file, :processed_headers, :args,
-                :ssl_version, :ssl_ca_path
+                :ssl_version, :ssl_ca_path, :ssl_ca_store
 
     def self.execute(args, & block)
       new(args).execute(& block)
@@ -58,6 +58,7 @@ module RestClient
       @ssl_ca_file = args[:ssl_ca_file] || nil
       @ssl_ca_path = args[:ssl_ca_path] || nil
       @ssl_version = args[:ssl_version] || 'SSLv3'
+      @ssl_ca_store = args[:ssl_ca_store] || nil
       @tf = nil # If you are a raw request, this is your tempfile
       @max_redirects = args[:max_redirects] || 10
       @processed_headers = make_headers headers
@@ -169,6 +170,7 @@ module RestClient
       net.ca_path = @ssl_ca_path if @ssl_ca_path
       net.read_timeout = @timeout if @timeout
       net.open_timeout = @open_timeout if @open_timeout
+      net.cert_store = @ssl_ca_store if @ssl_ca_store
 
       # disable the timeout if the timeout value is -1
       net.read_timeout = nil if @timeout == -1

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -15,6 +15,7 @@ describe RestClient::Request do
     @net.stub(:start).and_yield(@http)
     @net.stub(:use_ssl=)
     @net.stub(:verify_mode=)
+    @net.stub(:ssl_version=)
     RestClient.log = nil
   end
 
@@ -590,6 +591,39 @@ describe RestClient::Request do
       @request.stub(:response_log)
       @request.transmit(@uri, 'req', 'payload')
     end
+  end
+
+  it "should default to not having a ssl_ca_store" do
+    expect(@request.ssl_ca_store).to be_nil
+  end
+
+  it "should set the ssl_ca_store when provided" do
+    store = double("X509 Store")
+
+    @request = RestClient::Request.new(
+      :method => 'put',
+      :url => 'https://some/resource',
+      :ssl_ca_store => store
+    )
+
+    @net.should_receive(:cert_store=).with(store)
+    @http.stub(:request)
+    @request.stub(:process_result)
+    @request.stub(:response_log)
+    @request.transmit(@uri, 'req', 'payload')
+  end
+
+  it "should not set the ssl_ca_store when it is not provided" do
+    @request = RestClient::Request.new(
+      :method => 'put',
+      :url => 'https://some/resource'
+    )
+
+    @net.should_not_receive(:cert_store=)
+    @http.stub(:request)
+    @request.stub(:process_result)
+    @request.stub(:response_log)
+    @request.transmit(@uri, 'req', 'payload')
   end
 
   it "should still return a response object for 204 No Content responses" do


### PR DESCRIPTION
Adds support for passing a OpenSSL Certificate Store down to Net::HTTP like the other SSL settings. This allows for more flexibility when specifying valid CAs.
