### PR TITLE
Verifies ssl by default.

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -52,7 +52,8 @@ module RestClient
       @open_timeout = args[:open_timeout]
       @block_response = args[:block_response]
       @raw_response = args[:raw_response] || false
-      @verify_ssl = args[:verify_ssl] || false
+      @verify_ssl = OpenSSL::SSL::VERIFY_PEER # ssl by default
+      @verify_ssl = args[:verify_ssl] unless args[:verify_ssl].nil?
       @ssl_client_cert = args[:ssl_client_cert] || nil
       @ssl_client_key = args[:ssl_client_key] || nil
       @ssl_ca_file = args[:ssl_ca_file] || nil

--- a/spec/integration/request_spec.rb
+++ b/spec/integration/request_spec.rb
@@ -14,7 +14,6 @@ describe RestClient::Request do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'https://www.mozilla.com',
-        :verify_ssl => OpenSSL::SSL::VERIFY_PEER,
         :ssl_ca_file => File.join(File.dirname(__FILE__), "certs", "equifax.crt")
       )
       expect { request.execute }.to_not raise_error
@@ -24,7 +23,6 @@ describe RestClient::Request do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'https://www.mozilla.com',
-        :verify_ssl => OpenSSL::SSL::VERIFY_PEER,
         :ssl_ca_path => File.join(File.dirname(__FILE__), "capath_equifax")
       )
       expect { request.execute }.to_not raise_error
@@ -44,7 +42,6 @@ describe RestClient::Request do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'https://www.mozilla.com',
-        :verify_ssl => OpenSSL::SSL::VERIFY_PEER,
         :ssl_ca_file => File.join(File.dirname(__FILE__), "certs", "verisign.crt")
       )
       expect { request.execute }.to raise_error(RestClient::SSLCertificateNotVerified)
@@ -54,7 +51,6 @@ describe RestClient::Request do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'https://www.mozilla.com',
-        :verify_ssl => OpenSSL::SSL::VERIFY_PEER,
         :ssl_ca_path => File.join(File.dirname(__FILE__), "capath_verisign")
       )
       expect { request.execute }.to raise_error(RestClient::SSLCertificateNotVerified)

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -15,6 +15,7 @@ describe RestClient::Request do
     @net.stub(:start).and_yield(@http)
     @net.stub(:use_ssl=)
     @net.stub(:verify_mode=)
+    @net.stub(:verify_callback=)
     RestClient.log = nil
   end
 
@@ -412,11 +413,13 @@ describe RestClient::Request do
       @request.transmit(@uri, 'req', 'payload')
     end
 
-    it "should default to not verifying ssl certificates" do
-      @request.verify_ssl.should eq false
+    it "should default to verifying ssl certificates" do
+      @request.verify_ssl.should eq OpenSSL::SSL::VERIFY_PEER
     end
 
     it "should set net.verify_mode to OpenSSL::SSL::VERIFY_NONE if verify_ssl is false" do
+      @request = RestClient::Request.new(:method => :put, :verify_ssl => false, :url => 'http://some/resource', :payload => 'payload')
+
       @net.should_receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
       @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub(:request)
@@ -426,7 +429,6 @@ describe RestClient::Request do
     end
 
     it "should not set net.verify_mode to OpenSSL::SSL::VERIFY_NONE if verify_ssl is true" do
-      @request = RestClient::Request.new(:method => :put, :url => 'https://some/resource', :payload => 'payload', :verify_ssl => true, :ssl_version => 'SSLv3')
       @net.should_not_receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
       @net.should_receive(:ssl_version=).with('SSLv3')
       @http.stub(:request)


### PR DESCRIPTION
Fixes #139

Changes behavior to: Default to verifying ssl certificates by OpenSSL's default means, opt-out by adding :verify_ssl => false as an option for the request.

This will likely break situations, albeit undesired, where silent verification failure was occurring but going unnoticed.

Updates tests to reflect that change.

Can somebody make sure the integration tests pass? I don't have the local issuer of the checked-in certs used by those tests, so the tests obviously fail.
