### PR TITLE
Added exception for 429: Too Many Requests

### DIFF
--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -47,6 +47,7 @@ module RestClient
               424 => 'Failed Dependency', #WebDAV
               425 => 'Unordered Collection', #WebDAV
               426 => 'Upgrade Required',
+              429 => 'Too Many Requests', #RFC6585
               449 => 'Retry With', #Microsoft
               450 => 'Blocked By Windows Parental Controls', #Microsoft
 


### PR DESCRIPTION
429 is pretty widely used for rate limiting - it'd be great to be able to easily catch this common case.
