### PR TITLE
Payload Support For DELETE

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -46,7 +46,7 @@ dependencies for you.
 
   RestClient.delete 'http://example.com/resource'
 
-  RestClient.delete 'http://example.com/resource'. :param1 => 'one'
+  RestClient.delete 'http://example.com/resource', :param1 => 'one'
 
   response = RestClient.get 'http://example.com/resource'
   response.code

--- a/README.rdoc
+++ b/README.rdoc
@@ -46,6 +46,8 @@ dependencies for you.
 
   RestClient.delete 'http://example.com/resource'
 
+  RestClient.delete 'http://example.com/resource'. :param1 => 'one'
+
   response = RestClient.get 'http://example.com/resource'
   response.code
   ➔ 200

--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -40,6 +40,7 @@ require File.dirname(__FILE__) + '/restclient/net_http_ext'
 #
 #   # DELETE
 #   RestClient.delete 'http://example.com/resource'
+#   RestClient.delete 'http://example.com/resource', :param1 => 'one'
 #
 #   # retreive the response http code and headers
 #   res = RestClient.get 'http://example.com/some.jpg'
@@ -80,8 +81,8 @@ module RestClient
     Request.execute(:method => :put, :url => url, :payload => payload, :headers => headers, &block)
   end
 
-  def self.delete(url, headers={}, &block)
-    Request.execute(:method => :delete, :url => url, :headers => headers, &block)
+  def self.delete(url, payload, headers={}, &block)
+    Request.execute(:method => :delete, :url => url, :payload => payload, :headers => headers, &block)
   end
 
   def self.head(url, headers={}, &block)

--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -81,7 +81,7 @@ module RestClient
     Request.execute(:method => :put, :url => url, :payload => payload, :headers => headers, &block)
   end
 
-  def self.delete(url, payload, headers={}, &block)
+  def self.delete(url, payload=nil, headers={}, &block)
     Request.execute(:method => :delete, :url => url, :payload => payload, :headers => headers, &block)
   end
 

--- a/lib/restclient/resource.rb
+++ b/lib/restclient/resource.rb
@@ -89,11 +89,12 @@ module RestClient
               :headers => headers), &(block || @block))
     end
 
-    def delete(additional_headers={}, &block)
+    def delete(payload, additional_headers={}, &block)
       headers = (options[:headers] || {}).merge(additional_headers)
       Request.execute(options.merge(
               :method => :delete,
               :url => url,
+              :payload => payload,
               :headers => headers), &(block || @block))
     end
 

--- a/lib/restclient/resource.rb
+++ b/lib/restclient/resource.rb
@@ -89,7 +89,7 @@ module RestClient
               :headers => headers), &(block || @block))
     end
 
-    def delete(payload, additional_headers={}, &block)
+    def delete(payload=nil, additional_headers={}, &block)
       headers = (options[:headers] || {}).merge(additional_headers)
       Request.execute(options.merge(
               :method => :delete,

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -32,8 +32,8 @@ describe RestClient::Resource do
     end
 
     it "DELETE" do
-      RestClient::Request.should_receive(:execute).with(:method => :delete, :url => 'http://some/resource', :headers => {'X-Something' => '1'}, :user => 'jane', :password => 'mypass')
-      @resource.delete
+      RestClient::Request.should_receive(:execute).with(:method => :delete, :url => 'http://some/resource', :payload => 'abc', :headers => {'X-Something' => '1'}, :user => 'jane', :password => 'mypass')
+      @resource.delete 'abc'
     end
 
     it "overrides resource headers" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -35,6 +35,11 @@ describe RestClient::Resource do
       RestClient::Request.should_receive(:execute).with(:method => :delete, :url => 'http://some/resource', :payload => 'abc', :headers => {'X-Something' => '1'}, :user => 'jane', :password => 'mypass')
       @resource.delete 'abc'
     end
+    
+    it "DELETE" do
+      RestClient::Request.should_receive(:execute).with(:method => :delete, :url => 'http://some/resource', :payload => nil, :headers => {'X-Something' => '1'}, :user => 'jane', :password => 'mypass')
+      @resource.delete
+    end
 
     it "overrides resource headers" do
       RestClient::Request.should_receive(:execute).with(:method => :get, :url => 'http://some/resource', :headers => {'X-Something' => '2'}, :user => 'jane', :password => 'mypass')

--- a/spec/unit/restclient_spec.rb
+++ b/spec/unit/restclient_spec.rb
@@ -23,8 +23,8 @@ describe RestClient do
     end
 
     it "DELETE" do
-      RestClient::Request.should_receive(:execute).with(:method => :delete, :url => 'http://some/resource', :headers => {})
-      RestClient.delete('http://some/resource')
+      RestClient::Request.should_receive(:execute).with(:method => :delete, :url => 'http://some/resource', :payload => 'payload', :headers => {})
+      RestClient.delete('http://some/resource', 'payload')
     end
 
     it "HEAD" do


### PR DESCRIPTION
Added optional payload support for DELETE method. Supports the old method (without payloads) and the new method (as an optional payload parameter).
