### PR TITLE
Payload::Base.to_s doesn't reset stream position

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -114,9 +114,7 @@ module RestClient
       end
 
       def inspect
-        result = to_s.inspect
-        @stream.seek(0)
-        result
+        to_s.inspect
       end
 
       def short_inspect

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -62,7 +62,11 @@ module RestClient
         @stream.read(bytes)
       end
 
-      alias :to_s :read
+      def to_s
+        result = read
+        @stream.seek(0)
+        result
+      end
 
       # Flatten parameters by converting hashes of hashes to flat hashes
       # {keys1 => {keys2 => value}} will be transformed into [keys1[key2], value]

--- a/spec/unit/payload_spec.rb
+++ b/spec/unit/payload_spec.rb
@@ -3,6 +3,14 @@
 require 'spec_helper'
 
 describe RestClient::Payload do
+  context "Base Payload" do
+    it "should reset stream after to_s" do
+      payload = RestClient::Payload::Base.new('foobar')
+      payload.to_s.should eq 'foobar'
+      payload.to_s.should eq 'foobar'
+    end
+  end
+
   context "A regular Payload" do
     it "should use standard enctype as default content-type" do
       RestClient::Payload::UrlEncoded.new({}).headers['Content-Type'].


### PR DESCRIPTION
Payload::Base.to_s doesn't reset stream position so calling it twice (or more) will return empty. Not sure if this was the expected behaviour, but I didn't seem right to me, so I did a test and a fix for it.