### PR TITLE
Set encoding of the response string, if specified by server.

### DIFF
--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -17,7 +17,26 @@ module RestClient
       result.extend Response
       result.net_http_res = net_http_res
       result.args = args
-      result
+      fix_encoding(result)
+    end
+
+    private
+
+    def self.fix_encoding(response)
+      charset  = response.headers[:content_type].to_s[/\bcharset=([^ ]+)/, 1]
+      encoding = nil
+
+      begin
+        encoding = Encoding.find(charset) unless charset.nil?
+      rescue ArgumentError => e
+        RestClient.log "No such encoding: #{charset}"
+      end
+
+      if encoding && response.body.clone.force_encoding(encoding).valid_encoding?
+        response.body.force_encoding(encoding)
+      end
+
+      response
     end
 
   end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'spec_helper'
 
 describe RestClient do
@@ -31,5 +32,10 @@ describe RestClient do
     end
   end
 
-
+  it "has the right encoding" do
+    body = "λ".force_encoding('ASCII-8BIT')
+    stub_request(:get, "www.example.com").to_return(:body => body, :status => 200, :headers => { 'Content-Type' => 'text/plain; charset=UTF-8' })
+    response = RestClient.get "www.example.com"
+    response.encoding.should eq Encoding::UTF_8
+  end
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -50,7 +50,7 @@ describe RestClient::Request do
   end
 
   it "processes a successful result" do
-    res = double("result")
+    res = double("result", :to_hash => {})
     res.stub(:code).and_return("200")
     res.stub(:body).and_return('body')
     res.stub(:[]).with('content-encoding').and_return(nil)
@@ -60,7 +60,7 @@ describe RestClient::Request do
 
   it "doesn't classify successful requests as failed" do
     203.upto(207) do |code|
-      res = double("result")
+      res = double("result", :to_hash => {})
       res.stub(:code).and_return(code.to_s)
       res.stub(:body).and_return("")
       res.stub(:[]).with('content-encoding').and_return(nil)
@@ -332,24 +332,24 @@ describe RestClient::Request do
 
   describe "exception" do
     it "raises Unauthorized when the response is 401" do
-      res = double('response', :code => '401', :[] => ['content-encoding' => ''], :body => '' )
+      res = double('response', :code => '401', :[] => ['content-encoding' => ''], :body => '', :to_hash => {})
       lambda { @request.process_result(res) }.should raise_error(RestClient::Unauthorized)
     end
 
     it "raises ResourceNotFound when the response is 404" do
-      res = double('response', :code => '404', :[] => ['content-encoding' => ''], :body => '' )
+      res = double('response', :code => '404', :[] => ['content-encoding' => ''], :body => '', :to_hash => {})
       lambda { @request.process_result(res) }.should raise_error(RestClient::ResourceNotFound)
     end
 
     it "raises RequestFailed otherwise" do
-      res = double('response', :code => '500', :[] => ['content-encoding' => ''], :body => '' )
+      res = double('response', :code => '500', :[] => ['content-encoding' => ''], :body => '', :to_hash => {})
       lambda { @request.process_result(res) }.should raise_error(RestClient::InternalServerError)
     end
   end
 
   describe "block usage" do
     it "returns what asked to" do
-      res = double('response', :code => '401', :[] => ['content-encoding' => ''], :body => '' )
+      res = double('response', :code => '401', :[] => ['content-encoding' => ''], :body => '', :to_hash => {})
       @request.process_result(res){|response, request| "foo"}.should eq "foo"
     end
   end

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -55,7 +55,7 @@ describe RestClient::Response do
   describe "exceptions processing" do
     it "should return itself for normal codes" do
       (200..206).each do |code|
-        net_http_res = double('net http response', :code => '200')
+        net_http_res = double('net http response', :code => '200', :to_hash => {})
         response = RestClient::Response.create('abc', net_http_res, {})
         response.return! @request
       end
@@ -64,7 +64,7 @@ describe RestClient::Response do
     it "should throw an exception for other codes" do
       RestClient::Exceptions::EXCEPTIONS_MAP.each_key do |code|
         unless (200..207).include? code
-          net_http_res = double('net http response', :code => code.to_i)
+          net_http_res = double('net http response', :code => code.to_i, :to_hash => {})
           response = RestClient::Response.create('abc', net_http_res, {})
           lambda { response.return!}.should raise_error
         end
@@ -94,25 +94,25 @@ describe RestClient::Response do
     end
 
     it "doesn't follow a 301 when the request is a post" do
-      net_http_res = double('net http response', :code => 301)
+      net_http_res = double('net http response', :code => 301, :to_hash => {})
       response = RestClient::Response.create('abc', net_http_res, {:method => :post})
       lambda { response.return!(@request)}.should raise_error(RestClient::MovedPermanently)
     end
 
     it "doesn't follow a 302 when the request is a post" do
-      net_http_res = double('net http response', :code => 302)
+      net_http_res = double('net http response', :code => 302, :to_hash => {})
       response = RestClient::Response.create('abc', net_http_res, {:method => :post})
       lambda { response.return!(@request)}.should raise_error(RestClient::Found)
     end
 
     it "doesn't follow a 307 when the request is a post" do
-      net_http_res = double('net http response', :code => 307)
+      net_http_res = double('net http response', :code => 307, :to_hash => {})
       response = RestClient::Response.create('abc', net_http_res, {:method => :post})
       lambda { response.return!(@request)}.should raise_error(RestClient::TemporaryRedirect)
     end
 
     it "doesn't follow a redirection when the request is a put" do
-      net_http_res = double('net http response', :code => 301)
+      net_http_res = double('net http response', :code => 301, :to_hash => {})
       response = RestClient::Response.create('abc', net_http_res, {:method => :put})
       lambda { response.return!(@request)}.should raise_error(RestClient::MovedPermanently)
     end


### PR DESCRIPTION
The encoding of the response string is always reported as 'ASCII-8BIT',
even when the underlying byte sequence is valid UTF-8 and the server
advertises it as UTF-8 in the Content-Type header.

With this commit, the Content-Type header in the server response is
checked for a charset defintion and the response string encoding set
accordingly.  If there is a mismatch between the advertised and the
actual encoding, the response encoding is left as 'ASCII-8BIT'.

The following irb session illustrates the problem:

```
irb(main):001:0> require 'restclient'
=> true
irb(main):002:0> response = RestClient.get 'http://www.goldenerunkelruebe.de'; response.code
=> 200
irb(main):003:0> response.encoding
=> #<Encoding:ASCII-8BIT>
irb(main):004:0> response.headers[:content_type]
=> "text/html; charset=UTF-8"
```