### PR TITLE
RestClient.tmpdir config

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -96,6 +96,12 @@ module RestClient
 
   class << self
     attr_accessor :proxy
+
+    #customizable tmpdir for created files
+    attr_writer :tmpdir
+    def tmpdir
+      @tmpdir || Dir.tmpdir
+    end
   end
 
   # Setup the log for RestClient calls.

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -166,7 +166,7 @@ module RestClient
       def build_stream(params)
         b = "--#{boundary}"
 
-        @stream = Tempfile.new("RESTClient.Stream.#{rand(1000)}")
+        @stream = Tempfile.new("RESTClient.Stream.#{rand(1000)}", RestClient.tmpdir)
         @stream.binmode
         @stream.write(b + EOL)
 

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -452,7 +452,7 @@ module RestClient
         # Taken from Chef, which as in turn...
         # Stolen from http://www.ruby-forum.com/topic/166423
         # Kudos to _why!
-        @tf = Tempfile.new("rest-client")
+        @tf = Tempfile.new("rest-client", RestClient.tmpdir)
         @tf.binmode
         size, total = 0, http_response.header['Content-Length'].to_i
         http_response.read_body do |chunk|

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -895,7 +895,7 @@ describe RestClient::Request do
       tempfile.should_receive(:binmode)
       tempfile.stub(:open)
       tempfile.stub(:close)
-      Tempfile.should_receive(:new).with("rest-client").and_return(tempfile)
+      Tempfile.should_receive(:new).with("rest-client", Dir.tmpdir).and_return(tempfile)
 
       net_http_res = Net::HTTPOK.new(nil, "200", "body")
       net_http_res.stub(:read_body).and_return("body")


### PR DESCRIPTION
Added support for API clients to specify an alternate tmpdir for underlying Tempfile.new() calls, allowing large-file use-cases to be customized to write to somewhere on disk (e.g. /var/tmp) and avoid filling up the memory-backed /tmp filesystem without having to change the global Dir.tmpdir with env vars.
