### PR TITLE
Don't redo so much work creating URL-encoded params.

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -147,7 +147,7 @@ module RestClient
 
       # for UrlEncoded escape the keys
       def handle_key key
-        parser.escape(key.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+        Parser.escape(key.to_s, Escape)
       end
 
       def headers
@@ -155,9 +155,8 @@ module RestClient
       end
 
       private
-        def parser
-          URI.const_defined?(:Parser) ? URI::Parser.new : URI
-        end
+      Parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
+      Escape = Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")
     end
 
     class Multipart < Base


### PR DESCRIPTION
Create a single URI::Parser and a single Regexp object, and reuse them.

On my laptop, this reduces the time needed by

``` ruby
RestClient::Payload.generate({topic: 'performance', key: 'rest-client', value: 'better'})
```

from a whopping 7ms to a negligible 0.01ms.
