### PR TITLE
1.6: Move rdoc to development dependency

### DIFF
--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.summary = 'Simple HTTP and REST client for Ruby, inspired by microframework syntax for specifying actions.'
 
   s.add_dependency(%q<mime-types>, ["~> 1.16"])
-  s.add_dependency(%q<rdoc>, [">= 2.4.2"])
+  s.add_development_dependency(%q<rdoc>, [">= 2.4.2"])
   s.add_development_dependency(%q<rake>, ["~> 10.0"])
   s.add_development_dependency(%q<webmock>, ["~> 1.4"])
   s.add_development_dependency(%q<rspec>, ["~> 2.4"])


### PR DESCRIPTION
82b2394cf14a1592aba061f21c2aee172036838e added `rdoc` to runtime dependency - it should be on development dependency.
