### PR TITLE
Quietly ignore errors while attempting to read .netrc

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -281,7 +281,11 @@ module RestClient
       @user = CGI.unescape(uri.user) if uri.user
       @password = CGI.unescape(uri.password) if uri.password
       if !@user && !@password
-        @user, @password = Netrc.read[uri.host]
+        begin
+          @user, @password = Netrc.read[uri.host]
+        rescue SystemCallError
+          # Quietly ignore errors reading ~/.netrc
+        end
       end
       uri
     end


### PR DESCRIPTION
Netrc.read() handles Errno::ENOENT, but nothing else. I've seen
Errno::EACCES in production when ENV['HOME'] isn't sane. Since reading
.netrc is a non-critical path, ignore errors instead.