### PR TITLE
Documentation Updates to include examples for setting request headers.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -249,6 +249,17 @@ the URL for GET, HEAD and DELETE requests, escaping the keys and values as neede
   RestClient.get 'http://example.com/resource', :params => {:foo => 'bar', :baz => 'qux'}
   # will GET http://example.com/resource?foo=bar&baz=qux
 
+== Headers
+
+  # GET request with modified headers
+  RestClient.get 'http://example.com/resource', {:Authorization => 'Bearer cT0febFoD5lxAlNAXHo6g'}
+
+  # POST request with modified headers
+  RestClient.post 'http://example.com/resource', {:foo => 'bar', :baz => 'qux'}, {:Authorization => 'Bearer cT0febFoD5lxAlNAXHo6g'}
+
+  # DELETE request with modified headers
+  RestClient.delete 'http://example.com/resource', {:Authorization => 'Bearer cT0febFoD5lxAlNAXHo6g'}
+
 == Cookies
 
 Request and Response objects know about HTTP cookies, and will automatically

--- a/README.rdoc
+++ b/README.rdoc
@@ -251,6 +251,9 @@ the URL for GET, HEAD and DELETE requests, escaping the keys and values as neede
 
 == Headers
 
+Request headers can be set by passing a ruby hash containing keys and values
+representing header names and values:
+
   # GET request with modified headers
   RestClient.get 'http://example.com/resource', {:Authorization => 'Bearer cT0febFoD5lxAlNAXHo6g'}
 


### PR DESCRIPTION
Improving the readme by including explicit examples of how to set the headers of a request.

This makes it easier to people to understand how to set headers, and hopefully will help reduce issues like https://github.com/rest-client/rest-client/issues/227 going forward.