### PR TITLE
Fix RestClient::Request docs when used with yard

### DIFF
--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -195,8 +195,8 @@ module RestClient
   end
 end
 
-# backwards compatibility
 class RestClient::Request
+  # backwards compatibility
   Redirect = RestClient::Redirect
   Unauthorized = RestClient::Unauthorized
   RequestFailed = RestClient::RequestFailed


### PR DESCRIPTION
This moves a backwards compatibility comment.  It's currently replacing the class documentation, which means that most of the docs for this class are missing on rubydoc.info - http://rubydoc.info/gems/rest-client/RestClient/Request
