### PR TITLE
use mime-types version compatible with Ruby 1.9.2

### DIFF
--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry-doc')
   s.add_development_dependency('rdoc', '>= 2.4.2', '< 5.0')
 
-  s.add_dependency('mime-types', '>= 1.16', '< 3.0')
+  s.add_dependency('mime-types', '>= 1.16', '< 2.4.2') # 2.4.2 requires Ruby 1.9.3+
   s.add_dependency('netrc', '~> 0.7')
 
   s.required_ruby_version = '>= 1.9.2'


### PR DESCRIPTION
The latest version of mime-types gem 2.4.2 does not support Ruby 1.9.2.

This restriction can be removed when rest-client no longer supports 1.9.2.

I raised a mime-types issue to double check the issue: https://github.com/halostatue/mime-types/issues/77
