### PR TITLE
Fix of Don't automatically prepend http:// to URI #299

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -272,7 +272,7 @@ module RestClient
     end
 
     def parse_url(url)
-      url = "http://#{url}" unless url.match(/^http/)
+      url = "http://#{url}" unless url.match(/^*:\/\//)
       URI.parse(url)
     end
 


### PR DESCRIPTION
I changed the prepend behavior to be whenever it does not start from *:// (before it was http) 
