### PR TITLE
Expose Net::HTTP#keep_alive_timeout= as :keep_alive_timeout .

### DIFF
--- a/lib/restclient/resource.rb
+++ b/lib/restclient/resource.rb
@@ -20,6 +20,10 @@ module RestClient
   #
   #   RestClient::Resource.new('http://behindfirewall', :open_timeout => 10)
   #
+  # With an keep-alive timeout (seconds):
+  #
+  #   RestClient::Resource.new('http://lb', :keep_alive_timeout => 2)
+  #
   # You can also use resources to share common headers. For headers keys,
   # symbols are converted to strings. Example:
   #
@@ -119,6 +123,10 @@ module RestClient
 
     def open_timeout
       options[:open_timeout]
+    end
+
+    def keep_alive_timeout
+      options[:keep_alive_timeout]
     end
 
     # Construct a subresource, preserving authentication.

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -433,6 +433,7 @@ describe RestClient::Request do
 
       @net.should_not_receive(:read_timeout=)
       @net.should_not_receive(:open_timeout=)
+      @net.should_not_receive(:keep_alive_timeout=)
 
       @request.transmit(@uri, 'req', nil)
     end
@@ -459,20 +460,32 @@ describe RestClient::Request do
       @request.transmit(@uri, 'req', nil)
     end
 
+    it "set keep_alive_timeout" do
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :keep_alive_timeout => 42)
+      @http.stub(:request)
+      @request.stub(:process_result)
+      @request.stub(:response_log)
+
+      @net.should_receive(:keep_alive_timeout=).with(42)
+
+      @request.transmit(@uri, 'req', nil)
+    end
+
     it "disable timeout by setting it to nil" do
-      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => nil, :open_timeout => nil)
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => nil, :open_timeout => nil, :keep_alive_timeout => nil)
       @http.stub(:request)
       @request.stub(:process_result)
       @request.stub(:response_log)
 
       @net.should_receive(:read_timeout=).with(nil)
       @net.should_receive(:open_timeout=).with(nil)
+      @net.should_receive(:keep_alive_timeout=).with(nil)
 
       @request.transmit(@uri, 'req', nil)
     end
 
     it "deprecated: disable timeout by setting it to -1" do
-      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => -1, :open_timeout => -1)
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => -1, :open_timeout => -1, :keep_alive_timeout => -1)
       @http.stub(:request)
       @request.stub(:process_result)
       @request.stub(:response_log)
@@ -482,6 +495,9 @@ describe RestClient::Request do
 
       @request.should_receive(:warn)
       @net.should_receive(:open_timeout=).with(nil)
+
+      @request.should_receive(:warn)
+      @net.should_receive(:keep_alive_timeout=).with(nil)
 
       @request.transmit(@uri, 'req', nil)
     end


### PR DESCRIPTION
I propose exposing `Net::HTTP#keep_alive_timeout=`, to join existing `Net::HTTP#read_timeout=` and `Net::HTTP#open_timeout=` exposure. This could assist with certain types of connection configurations, particularly when using RestClient to connect to an API using a long-living connection.

Peace,
tiredpixel

---

Similar to existing `:timeout` (`Net::HTTP#read_timeout=`),
`:open_timeout` (`Net::HTTP#open_timeout=`), add `:keep_alive_timeout`
(`Net::HTTP#keep_alive_timeout`).

Note that timeout `-1` => `nil` with warning is replicated for
consistency with `:timeout`,`:open_timeout`, despite
`:keep_alive_timeout` being new.
