### PR TITLE
Use URI::Generic#hostname to strip brackets from ipv6 hosts

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -281,7 +281,7 @@ module RestClient
       @user = CGI.unescape(uri.user) if uri.user
       @password = CGI.unescape(uri.password) if uri.password
       if !@user && !@password
-        @user, @password = Netrc.read[uri.host]
+        @user, @password = Netrc.read[uri.hostname]
       end
       uri
     end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -145,7 +145,7 @@ describe RestClient::Request do
   end
 
   it "uses netrc credentials" do
-    URI.stub(:parse).and_return(double('uri', :user => nil, :password => nil, :host => 'example.com'))
+    URI.stub(:parse).and_return(double('uri', :user => nil, :password => nil, :hostname => 'example.com'))
     Netrc.stub(:read).and_return('example.com' => ['a', 'b'])
     @request.parse_url_with_auth('http://example.com/resource')
     @request.user.should eq 'a'
@@ -153,7 +153,7 @@ describe RestClient::Request do
   end
 
   it "uses credentials in the url in preference to netrc" do
-    URI.stub(:parse).and_return(double('uri', :user => 'joe%20', :password => 'pass1', :host => 'example.com'))
+    URI.stub(:parse).and_return(double('uri', :user => 'joe%20', :password => 'pass1', :hostname => 'example.com'))
     Netrc.stub(:read).and_return('example.com' => ['a', 'b'])
     @request.parse_url_with_auth('http://joe%20:pass1@example.com/resource')
     @request.user.should eq 'joe '


### PR DESCRIPTION
URI::Generic#host is not appropriate to pass socket methods such as TCPSocket.open.

See: https://bugs.ruby-lang.org/issues/3788
URI::Generic#hostname was added in ruby 1.9.3.
Commit: ruby/ruby@5fd45a4

From: [lib/uri/common.rb](https://github.com/ruby/ruby/blob/4cb3f72fddfbee1341b21a8ec7b82ae884dbd3c8/lib/uri/generic.rb#L232):

```
Since IPv6 addresses are wrapped by brackets in URIs,
this method returns IPv6 addresses wrapped by brackets.
This form is not appropriate to pass socket methods such as TCPSocket.open.
If unwrapped host names are required, use "hostname" method.

  URI("http://[::1]/bar/baz").host #=> "[::1]"
  URI("http://[::1]/bar/baz").hostname #=> "::1"
```

See also: nahi/httpclient#176

Note:  this is failing on travis for 1.9.2 since URI::Generic#hostname was added to ruby 1.9.3.

Since ruby 1.9.2 [ended extended end of life back in July](https://www.ruby-lang.org/en/news/2014/07/01/eol-for-1-8-7-and-1-9-2/), this should be ok.  Otherwise, we'd have to maintain a backport from ruby or only fix this issue with ruby 1.9.3 and greater.

If desired, I can bump the required ruby version to 1.9.3 in the travis.yml/gemspec but I wanted to propose the question first.

Finally, even with rest-client patched, there is a regression in net/http in ruby 2.0+:
[Fixed here](https://github.com/ruby/ruby/commit/f01485b4ec97d6bbc462f6c7210b2499a97ce398)
[buglink ](https://bugs.ruby-lang.org/issues/9129)

We have requested backports of this fix to [2.0](https://bugs.ruby-lang.org/issues/10530) and [2.1](https://bugs.ruby-lang.org/issues/10531).

Even if rest-client doesn't want to carry this backport as a monkey patch, it should be using URI::Generic#hostname for strings to be used in Socket connections.
