### PR TITLE
ruby 2+: delegate IPv6 [] wrapping to net/http by passing a URI object.

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -173,7 +173,11 @@ module RestClient
 
     def execute & block
       uri = parse_url_with_auth(url)
-      transmit uri, net_http_request_class(method).new(uri.request_uri, processed_headers), payload, & block
+
+      # With 2.0.0+, net/http accepts URI objects in requests and handles wrapping
+      # IPv6 addresses in [] for use in the Host request header.
+      request_uri = RUBY_VERSION >= "2.0.0" ? uri : uri.request_uri
+      transmit uri, net_http_request_class(method).new(request_uri, processed_headers), payload, & block
     ensure
       payload.close if payload
     end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -238,6 +238,21 @@ describe RestClient::Request do
     @request.execute
   end
 
+  it "IPv6: executes by constructing the Net::HTTP object, headers, and payload and calling transmit" do
+    @request = RestClient::Request.new(:method => :put, :url => 'http://[::1]/some/resource', :payload => 'payload')
+    klass = double("net:http class")
+    @request.should_receive(:net_http_request_class).with(:put).and_return(klass)
+
+    if RUBY_VERSION >= "2.0.0"
+      klass.should_receive(:new).with(kind_of(URI), kind_of(Hash)).and_return('result')
+    else
+      klass.should_receive(:new).with(kind_of(String), kind_of(Hash)).and_return('result')
+    end
+
+    @request.should_receive(:transmit)
+    @request.execute
+  end
+
   it "transmits the request with Net::HTTP" do
     @http.should_receive(:request).with('req', 'payload')
     @request.should_receive(:process_result)


### PR DESCRIPTION
Note: this is similar but different than #332.  Both issues are required to fix using IPv6 addresses with rest-client on ruby 2.0+.

net/http with Ruby 2+ will handle setting the Host header in the request correctly when you pass a URI object.

See: https://github.com/ruby/ruby/blob/8eb0c810b228df1f8352c005a7ae882ad4179b4b/lib/net/http/generic_request.rb#L17

Fixes 400/bad request error with IPv6 addresses.

For example, a good request with an ipv4 address, such as: 127.0.0.1:

```
starting SSL for 127.0.0.1:443...
SSL established
<- "GET /api HTTP/1.1\r\nAccept: */*; q=0.5, application/xml\r\nAccept-Encoding: gzip, deflate\r\nPrefer: persistent-auth\r\nUser-Agent: Ruby\r\nAuthorization: Basic ...\r\nHost: 127.0.0.1\r\n\r\n"
-> "HTTP/1.1 200 OK\r\n"
```

Now, a BAD request with the existing code and an ipv6 address, such as ::1:

```
starting SSL for ::1:443...
SSL established
<- "GET /api HTTP/1.1\r\nAccept: */*; q=0.5, application/xml\r\nAccept-Encoding: gzip, deflate\r\nPrefer: persistent-auth\r\nUser-Agent: Ruby\r\nAuthorization: Basic ...\r\nHost: ::1\r\n\r\n"
-> "HTTP/1.1 400 Bad Request\r\n"
```

Now, the same request with the changed code:

```
starting SSL for ::1:443...
SSL established
<- "GET /api HTTP/1.1\r\nAccept: */*; q=0.5, application/xml\r\nAccept-Encoding: gzip, deflate\r\nPrefer: persistent-auth\r\nUser-Agent: Ruby\r\nAuthorization: Basic ...\r\nHost: [::1]\r\n\r\n"
-> "HTTP/1.1 200 OK\r\n"
```

Note: the Host request header is properly wrapped in [].
