### PR TITLE
Also pass timeout parameters to redirected request.

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -74,6 +74,8 @@ module RestClient
         args[:user] = request.user
         args[:headers] = request.headers
         args[:max_redirects] = request.max_redirects - 1
+        args[:timeout] = request.timeout
+        args[:open_timeout] = request.open_timeout
         # pass any cookie set in the result
         if result && result['set-cookie']
           args[:headers][:cookies] = (args[:headers][:cookies] || {}).merge(parse_cookie(result['set-cookie']))


### PR DESCRIPTION
Hi!

When following a redirection, the timeout parameters get lost in the new request.

I would have added a test, but I'm not sure how, as currently all tests are using WebMocks stub_request and I have no clue how to test for additional parameters with that.

If you have an idea how to test that, I'll add a corresponding spec.

Thanks!
  Martin
