### PR TITLE
Don't monkey patch MIME::Types

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -562,7 +562,7 @@ module RestClient
         end
         if 'CONTENT-TYPE' == key.upcase
           target_value = value.to_s
-          result[key] = MIME::Types.type_for_extension target_value
+          result[key] = type_for_extension target_value
         elsif 'ACCEPT' == key.upcase
           # Accept can be composed of several comma-separated values
           if value.is_a? Array
@@ -570,7 +570,7 @@ module RestClient
           else
             target_values = value.to_s.split ','
           end
-          result[key] = target_values.map { |ext| MIME::Types.type_for_extension(ext.to_s.strip) }.join(', ')
+          result[key] = target_values.map { |ext| type_for_extension(ext.to_s.strip) }.join(', ')
         else
           result[key] = value.to_s
         end
@@ -592,22 +592,10 @@ module RestClient
       URI.const_defined?(:Parser) ? URI::Parser.new : URI
     end
 
-  end
-end
-
-module MIME
-  class Types
-
-    # Return the first found content-type for a value considered as an extension or the value itself
     def type_for_extension ext
-      candidates = @extension_index[ext]
+      candidates = MIME::Types.type_for(ext)
       candidates.empty? ? ext : candidates[0].content_type
     end
 
-    class << self
-      def type_for_extension ext
-        @__types__.type_for_extension ext
-      end
-    end
   end
 end


### PR DESCRIPTION
There is currently a bug in the mime-types gem cached load which causes the monkey patch to error.

You can see this by setting ```export RUBY_MIME_TYPES_CACHE=mime.cache``` in your terminal and then run the tests twice. The first run will generate the cache file. The second run will use the cache file and you will see a mostly red test suite.

While this is actually a bug in the mime-types gem, for which I will be submitting a pull request, there is no need to monkey patch the MIME::Types class here. This PR will work whether they accept my mime-types PR or not.