### PR TITLE
Use MIME::Types.of instead of hacked-on intrusive monkey patch

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -562,7 +562,7 @@ module RestClient
         end
         if 'CONTENT-TYPE' == key.upcase
           target_value = value.to_s
-          result[key] = MIME::Types.type_for_extension target_value
+          result[key] = content_type_for target_value
         elsif 'ACCEPT' == key.upcase
           # Accept can be composed of several comma-separated values
           if value.is_a? Array
@@ -570,7 +570,7 @@ module RestClient
           else
             target_values = value.to_s.split ','
           end
-          result[key] = target_values.map { |ext| MIME::Types.type_for_extension(ext.to_s.strip) }.join(', ')
+          result[key] = target_values.map { |ext| content_type_for(ext.to_s.strip) }.join(', ')
         else
           result[key] = value.to_s
         end
@@ -592,22 +592,10 @@ module RestClient
       URI.const_defined?(:Parser) ? URI::Parser.new : URI
     end
 
-  end
-end
-
-module MIME
-  class Types
-
-    # Return the first found content-type for a value considered as an extension or the value itself
-    def type_for_extension ext
-      candidates = @extension_index[ext]
+    # Return the content-type for a value considered as an extension or the value itself
+    def content_type_for ext
+      candidates = MIME::Types.of ext
       candidates.empty? ? ext : candidates[0].content_type
-    end
-
-    class << self
-      def type_for_extension ext
-        @__types__.type_for_extension ext
-      end
     end
   end
 end


### PR DESCRIPTION
The monkey patch sidestepped MIME::Types accessors and broke when using RUBY_MIME_TYPES_LAZY_LOAD.