### PR TITLE
Fixed cookie reserved names

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -95,7 +95,7 @@ module RestClient
     def parse_cookie cookie_content
       out = {}
       CGI::Cookie::parse(cookie_content).each do |key, cookie|
-        unless ['expires', 'path'].include? key
+        unless ['expires', 'path', 'domain', 'secure'].include? key.downcase
           out[CGI::escape(key)] = cookie.value[0] ? (CGI::escape(cookie.value[0]) || '') : ''
         end
       end

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -61,6 +61,11 @@ describe RestClient::AbstractResponse do
     @response.cookies.should eq({ 'session_id' => 'BAh7BzoNYXBwX25hbWUiEGFwcGxpY2F0aW9uOgpsb2dpbiIKYWRtaW4%3D%0A--08114ba654f17c04d20dcc5228ec672508f738ca' })
   end
 
+  it "removes all reserved words and is case insensitive" do
+    @net_http_res.should_receive(:to_hash).and_return('set-cookie' => ['key=value; path=/; domain=.example.com; EXPIRES=Tue, 21-Apr-2015 04:57:03 GMT; secure'])
+    @response.cookies.should eq({ 'key' => 'value' })
+  end
+
   it "can access the net http result directly" do
     @response.net_http_res.should eq @net_http_res
   end


### PR DESCRIPTION
Case doesn't matter for cookie reserved names. Previously did not include the `domain` key as reserved.

When you had a cookie with `Path=/` set (or something of the like), the case would bypass the reserved names fix. Also, `domain` was not previously included for reserved words. Added `secure` name as well.

See http://www.rfc-editor.org/rfc/rfc6265.txt