### PR TITLE
Respect Content-Type charset headers in responses 

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
---colour --format progress --order random
+--color
+--format progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: ruby
 rvm:
   - "1.9.3"
   - "2.0.0"
-  # Forgo 2.1.0 until Travis has a satisfactory fix for
-  # https://github.com/travis-ci/travis-ci/issues/2220
-  - "2.1"  # always the latest 2.1.x
+  - "2.1" # latest 2.1.x
+  - "2.2" # latest 2.2.x
   - "jruby-19mode"
 script:
   bundle exec rake test

--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -17,8 +17,27 @@ module RestClient
       result.extend Response
       result.net_http_res = net_http_res
       result.args = args
+      fix_encoding(result)
       result
     end
 
+    private
+
+    def self.fix_encoding(response)
+      charset = RestClient::Utils.get_encoding_from_headers(response.headers)
+      encoding = nil
+
+      begin
+        encoding = Encoding.find(charset) if charset
+      rescue ArgumentError
+        RestClient.log "No such encoding: #{charset.inspect}"
+      end
+
+      return unless encoding
+
+      response.body.force_encoding(encoding)
+
+      response
+    end
   end
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,0 +1,5 @@
+module Helpers
+  def response_double(opts={})
+    double('response', {:to_hash => {}}.merge(opts))
+  end
+end

--- a/spec/integration/_lib.rb
+++ b/spec/integration/_lib.rb
@@ -1,0 +1,1 @@
+require_relative '../spec_helper'

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -66,7 +66,7 @@ describe RestClient do
       response.encoding.should eq Encoding::BINARY
       lambda {
         response.encode('utf-8')
-      }.should_raise(Encoding::UndefinedConversionError)
+      }.should raise_error(Encoding::UndefinedConversionError)
       response.valid_encoding?.should eq true
     end
   end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require_relative '_lib'
+require 'base64'
 
 describe RestClient do
 
@@ -85,6 +86,28 @@ describe RestClient do
       response.valid_encoding?.should eq true
       response.length.should eq 5
       response.encode('utf-8').should eq body_utf8
+    end
+
+    it 'defaults to Encoding.default_external' do
+      stub_request(:get, 'www.example.com').to_return(
+        body: 'abc', status: 200, headers: {
+          'Content-Type' => 'text/plain'
+        })
+
+      response = RestClient.get 'www.example.com'
+      response.encoding.should eq Encoding.default_external
+    end
+
+    it 'leaves images as binary' do
+      gif = Base64.strict_decode64('R0lGODlhAQABAAAAADs=')
+
+      stub_request(:get, 'www.example.com').to_return(
+        body: gif, status: 200, headers: {
+          'Content-Type' => 'image/gif'
+        })
+
+      response = RestClient.get 'www.example.com'
+      response.encoding.should eq Encoding::BINARY
     end
   end
 end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient do
 
@@ -68,6 +68,23 @@ describe RestClient do
         response.encode('utf-8')
       }.should raise_error(Encoding::UndefinedConversionError)
       response.valid_encoding?.should eq true
+    end
+
+    it 'handles euc-jp' do
+      body = "\xA4\xA2\xA4\xA4\xA4\xA6\xA4\xA8\xA4\xAA".
+        force_encoding(Encoding::BINARY)
+      body_utf8 = 'あいうえお'
+      body_utf8.encoding.should eq Encoding::UTF_8
+
+      stub_request(:get, 'www.example.com').to_return(
+        :body => body, :status => 200, :headers => {
+          'Content-Type' => 'text/plain; charset=EUC-JP'
+      })
+      response = RestClient.get 'www.example.com'
+      response.encoding.should eq Encoding::EUC_JP
+      response.valid_encoding?.should eq true
+      response.length.should eq 5
+      response.encode('utf-8').should eq body_utf8
     end
   end
 end

--- a/spec/integration/request_spec.rb
+++ b/spec/integration/request_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient::Request do
   before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,20 @@
 require 'webmock/rspec'
-require 'restclient'
+require 'rest-client'
+
+require_relative './helpers'
+
+# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+RSpec.configure do |config|
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = 'random'
+
+  # add helpers
+  config.include Helpers, :include_helpers
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,6 @@ require_relative './helpers'
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.run_all_when_everything_filtered = true
-  config.filter_run :focus
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/unit/_lib.rb
+++ b/spec/unit/_lib.rb
@@ -1,0 +1,1 @@
+require_relative '../spec_helper'

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient::AbstractResponse do
 

--- a/spec/unit/exceptions_spec.rb
+++ b/spec/unit/exceptions_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient::Exception do
   it "returns a 'message' equal to the class name if the message is not set, because 'message' should not be nil" do

--- a/spec/unit/payload_spec.rb
+++ b/spec/unit/payload_spec.rb
@@ -1,6 +1,6 @@
 # encoding: binary
 
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient::Payload do
   context "A regular Payload" do

--- a/spec/unit/raw_response_spec.rb
+++ b/spec/unit/raw_response_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient::RawResponse do
   before do

--- a/spec/unit/request2_spec.rb
+++ b/spec/unit/request2_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient::Request do
 
@@ -26,7 +26,7 @@ describe RestClient::Request do
     stub_request(:post, 'http://some/resource').with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate'}).to_return(:body => 'foo', :status => 200)
     RestClient::Request.execute(:url => 'http://some/resource', :method => :post, :payload => {:file => test_file})
 
-    test_file.closed?.should be_true
+    test_file.closed?.should be true
   end
 
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+require_relative './_lib'
 
-describe RestClient::Request do
+describe RestClient::Request, :include_helpers do
   before do
     @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload')
 
@@ -50,7 +50,7 @@ describe RestClient::Request do
   end
 
   it "processes a successful result" do
-    res = double("result")
+    res = response_double
     res.stub(:code).and_return("200")
     res.stub(:body).and_return('body')
     res.stub(:[]).with('content-encoding').and_return(nil)
@@ -60,7 +60,7 @@ describe RestClient::Request do
 
   it "doesn't classify successful requests as failed" do
     203.upto(207) do |code|
-      res = double("result")
+      res = response_double
       res.stub(:code).and_return(code.to_s)
       res.stub(:body).and_return("")
       res.stub(:[]).with('content-encoding').and_return(nil)
@@ -381,24 +381,24 @@ describe RestClient::Request do
 
   describe "exception" do
     it "raises Unauthorized when the response is 401" do
-      res = double('response', :code => '401', :[] => ['content-encoding' => ''], :body => '' )
+      res = response_double(:code => '401', :[] => ['content-encoding' => ''], :body => '' )
       lambda { @request.process_result(res) }.should raise_error(RestClient::Unauthorized)
     end
 
     it "raises ResourceNotFound when the response is 404" do
-      res = double('response', :code => '404', :[] => ['content-encoding' => ''], :body => '' )
+      res = response_double(:code => '404', :[] => ['content-encoding' => ''], :body => '' )
       lambda { @request.process_result(res) }.should raise_error(RestClient::ResourceNotFound)
     end
 
     it "raises RequestFailed otherwise" do
-      res = double('response', :code => '500', :[] => ['content-encoding' => ''], :body => '' )
+      res = response_double(:code => '500', :[] => ['content-encoding' => ''], :body => '' )
       lambda { @request.process_result(res) }.should raise_error(RestClient::InternalServerError)
     end
   end
 
   describe "block usage" do
     it "returns what asked to" do
-      res = double('response', :code => '401', :[] => ['content-encoding' => ''], :body => '' )
+      res = response_double(:code => '401', :[] => ['content-encoding' => ''], :body => '' )
       @request.process_result(res){|response, request| "foo"}.should eq "foo"
     end
   end
@@ -406,7 +406,7 @@ describe RestClient::Request do
   describe "proxy" do
     it "creates a proxy class if a proxy url is given" do
       RestClient.stub(:proxy).and_return("http://example.com/")
-      @request.net_http_class.proxy_class?.should be_true
+      @request.net_http_class.proxy_class?.should be true
     end
 
     it "creates a proxy class with the correct address if a IPv6 proxy url is given" do
@@ -415,7 +415,7 @@ describe RestClient::Request do
     end
 
     it "creates a non-proxy class if a proxy url is not given" do
-      @request.net_http_class.proxy_class?.should be_false
+      @request.net_http_class.proxy_class?.should be_falsey
     end
   end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient::Resource do
   before do

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+require_relative '_lib'
 
-describe RestClient::Response do
+describe RestClient::Response, :include_helpers do
   before do
     @net_http_res = double('net http response', :to_hash => {"Status" => ["200 OK"]}, :code => 200)
     @request = double('http request', :user => nil, :password => nil)
@@ -55,7 +55,7 @@ describe RestClient::Response do
   describe "exceptions processing" do
     it "should return itself for normal codes" do
       (200..206).each do |code|
-        net_http_res = double('net http response', :code => '200')
+        net_http_res = response_double(:code => '200')
         response = RestClient::Response.create('abc', net_http_res, {})
         response.return! @request
       end
@@ -64,7 +64,7 @@ describe RestClient::Response do
     it "should throw an exception for other codes" do
       RestClient::Exceptions::EXCEPTIONS_MAP.each_key do |code|
         unless (200..207).include? code
-          net_http_res = double('net http response', :code => code.to_i)
+          net_http_res = response_double(:code => code.to_i)
           response = RestClient::Response.create('abc', net_http_res, {})
           lambda { response.return!}.should raise_error
         end
@@ -94,25 +94,25 @@ describe RestClient::Response do
     end
 
     it "doesn't follow a 301 when the request is a post" do
-      net_http_res = double('net http response', :code => 301)
+      net_http_res = response_double(:code => 301)
       response = RestClient::Response.create('abc', net_http_res, {:method => :post})
       lambda { response.return!(@request)}.should raise_error(RestClient::MovedPermanently)
     end
 
     it "doesn't follow a 302 when the request is a post" do
-      net_http_res = double('net http response', :code => 302)
+      net_http_res = response_double(:code => 302)
       response = RestClient::Response.create('abc', net_http_res, {:method => :post})
       lambda { response.return!(@request)}.should raise_error(RestClient::Found)
     end
 
     it "doesn't follow a 307 when the request is a post" do
-      net_http_res = double('net http response', :code => 307)
+      net_http_res = response_double(:code => 307)
       response = RestClient::Response.create('abc', net_http_res, {:method => :post})
       lambda { response.return!(@request)}.should raise_error(RestClient::TemporaryRedirect)
     end
 
     it "doesn't follow a redirection when the request is a put" do
-      net_http_res = double('net http response', :code => 301)
+      net_http_res = response_double(:code => 301)
       response = RestClient::Response.create('abc', net_http_res, {:method => :put})
       lambda { response.return!(@request)}.should raise_error(RestClient::MovedPermanently)
     end

--- a/spec/unit/restclient_spec.rb
+++ b/spec/unit/restclient_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient do
   describe "API" do

--- a/spec/unit/utils_spec.rb
+++ b/spec/unit/utils_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe RestClient::Utils do
   describe '.get_encoding_from_headers' do
-    it 'assumes ISO-8859-1 by default for text' do
+    it 'assumes no encoding by default for text' do
       headers = {:content_type => 'text/plain'}
       RestClient::Utils.get_encoding_from_headers(headers).
-        should eq 'ISO-8859-1'
+        should eq nil
     end
 
     it 'returns nil on failures' do

--- a/spec/unit/utils_spec.rb
+++ b/spec/unit/utils_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '_lib'
 
 describe RestClient::Utils do
   describe '.get_encoding_from_headers' do

--- a/spec/unit/windows/root_certs_spec.rb
+++ b/spec/unit/windows/root_certs_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../_lib'
 
 describe 'RestClient::Windows::RootCerts',
          :if => RestClient::Platform.windows? do


### PR DESCRIPTION
Look for `charset` in `Content-Type` responses and force the encoding of the body string to that encoding. Respect RFC 7231 and don't default to `ISO-8859-1` (contrary to obsoleted RFC 2616).

Fixes #278, #306 
