### PR TITLE
Deprecate :timeout in favor of :read_timeout.

### DIFF
--- a/history.md
+++ b/history.md
@@ -21,6 +21,8 @@ This release is largely API compatible, but makes several breaking changes.
 - Fix some support for using IPv6 addresses in URLs (still affected by Ruby
   2.0+ bug https://bugs.ruby-lang.org/issues/9129, with the fix expected to be
   backported to 2.0 and 2.1)
+- Rename `:timeout` to `:read_timeout`, but still support the old option with a
+  warning for now
 
 # 1.7.3
 

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -23,8 +23,10 @@ module RestClient
   # * :max_redirects maximum number of redirections (default to 10)
   # * :verify_ssl enable ssl verification, possible values are constants from
   #     OpenSSL::SSL::VERIFY_*, defaults to OpenSSL::SSL::VERIFY_PEER
-  # * :timeout and :open_timeout are how long to wait for a response and to
-  #     open a connection, in seconds. Pass nil to disable the timeout.
+  # * :read_timeout and :open_timeout are how long to wait for a response and
+  #     to open a connection, in seconds. Pass nil to disable the timeout. For
+  #     backwards compatibility, :timeout is supported as an alias for
+  #     :read_timeout.
   # * :ssl_client_cert, :ssl_client_key, :ssl_ca_file, :ssl_ca_path,
   #     :ssl_cert_store, :ssl_verify_callback, :ssl_verify_callback_warnings
   # * :ssl_version specifies the SSL version for the underlying Net::HTTP connection
@@ -35,7 +37,7 @@ module RestClient
     # TODO: rename timeout to read_timeout
 
     attr_reader :method, :url, :headers, :cookies,
-                :payload, :user, :password, :timeout, :max_redirects,
+                :payload, :user, :password, :read_timeout, :max_redirects,
                 :open_timeout, :raw_response, :processed_headers, :args,
                 :ssl_opts
 
@@ -116,7 +118,11 @@ module RestClient
       @user = args[:user]
       @password = args[:password]
       if args.include?(:timeout)
-        @timeout = args[:timeout]
+        warn('Deprecated: please use `:read_timeout` instead of `:timeout`')
+        @read_timeout = args[:timeout]
+      end
+      if args.include?(:read_timeout)
+        @read_timeout = args[:read_timeout]
       end
       if args.include?(:open_timeout)
         @open_timeout = args[:open_timeout]
@@ -412,16 +418,16 @@ module RestClient
         warn('Try passing :verify_ssl => false instead.')
       end
 
-      if defined? @timeout
-        if @timeout == -1
-          warn 'To disable read timeouts, please set timeout to nil instead of -1'
-          @timeout = nil
+      if defined? @read_timeout
+        if @read_timeout == -1
+          warn 'Deprecated: to disable timeouts, please use nil instead of -1'
+          @read_timeout = nil
         end
-        net.read_timeout = @timeout
+        net.read_timeout = @read_timeout
       end
       if defined? @open_timeout
         if @open_timeout == -1
-          warn 'To disable open timeouts, please set open_timeout to nil instead of -1'
+          warn 'Deprecated: to disable timeouts, please use nil instead of -1'
           @open_timeout = nil
         end
         net.open_timeout = @open_timeout

--- a/lib/restclient/resource.rb
+++ b/lib/restclient/resource.rb
@@ -14,7 +14,7 @@ module RestClient
   #
   # With a timeout (seconds):
   #
-  #   RestClient::Resource.new('http://slow', :timeout => 10)
+  #   RestClient::Resource.new('http://slow', :read_timeout => 10)
   #
   # With an open timeout (seconds):
   #
@@ -113,8 +113,8 @@ module RestClient
       options[:headers] || {}
     end
 
-    def timeout
-      options[:timeout]
+    def read_timeout
+      options[:read_timeout]
     end
 
     def open_timeout

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -2,4 +2,13 @@ module Helpers
   def response_double(opts={})
     double('response', {:to_hash => {}}.merge(opts))
   end
+
+  def fake_stderr
+    original_stderr = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original_stderr
+  end
 end

--- a/spec/integration/request_spec.rb
+++ b/spec/integration/request_spec.rb
@@ -103,7 +103,7 @@ describe RestClient::Request do
   end
 
   describe "timeouts" do
-    it "raises ConnectTimeout when it hits an open timeout" do
+    it "raises OpenTimeout when it hits an open timeout" do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'http://www.mozilla.org',
@@ -113,11 +113,11 @@ describe RestClient::Request do
         raise_error(RestClient::Exceptions::OpenTimeout))
     end
 
-    it "raises RequestTimeout when it hits a read timeout via :timeout" do
+    it "raises ReadTimeout when it hits a read timeout via :read_timeout" do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'https://www.mozilla.org',
-        :timeout => 1e-10,
+        :read_timeout => 1e-10,
       )
       expect { request.execute }.to(
         raise_error(RestClient::Exceptions::ReadTimeout))

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -503,8 +503,21 @@ describe RestClient::Request, :include_helpers do
       @request.transmit(@uri, 'req', nil)
     end
 
-    it "set read_timeout" do
-      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => 123)
+    it 'sets read_timeout' do
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :read_timeout => 123)
+      @http.stub(:request)
+      @request.stub(:process_result)
+      @request.stub(:response_log)
+
+      @net.should_receive(:read_timeout=).with(123)
+
+      @request.transmit(@uri, 'req', nil)
+    end
+
+    it 'deprecated: sets read_timeout via :timeout' do
+      fake_stderr {
+        @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => 123)
+      }.should match(/^Deprecated: .*:read_timeout.*:timeout/)
       @http.stub(:request)
       @request.stub(:process_result)
       @request.stub(:response_log)
@@ -526,7 +539,7 @@ describe RestClient::Request, :include_helpers do
     end
 
     it "disable timeout by setting it to nil" do
-      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => nil, :open_timeout => nil)
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :read_timeout => nil, :open_timeout => nil)
       @http.stub(:request)
       @request.stub(:process_result)
       @request.stub(:response_log)
@@ -538,7 +551,7 @@ describe RestClient::Request, :include_helpers do
     end
 
     it "deprecated: disable timeout by setting it to -1" do
-      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => -1, :open_timeout => -1)
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :read_timeout => -1, :open_timeout => -1)
       @http.stub(:request)
       @request.stub(:process_result)
       @request.stub(:response_log)


### PR DESCRIPTION
This better matches the behavior of Net::HTTP and will make it more
obvious to users what the option actually does.