### PR TITLE
Add standards-compliant cookie handling.

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -5,7 +5,7 @@ module RestClient
 
   module AbstractResponse
 
-    attr_reader :net_http_res, :args
+    attr_reader :net_http_res, :args, :request
 
     # HTTP status code
     def code
@@ -23,11 +23,17 @@ module RestClient
       @raw_headers ||= @net_http_res.to_hash
     end
 
+    def response_set_vars(net_http_res, args, request)
+      @net_http_res = net_http_res
+      @args = args
+      @request = request
+    end
+
     # Hash of cookies extracted from response headers
     def cookies
       hash = {}
 
-      cookie_jar.cookies.each do |out, cookie|
+      cookie_jar.cookies.each do |cookie|
         hash[cookie.name] = cookie.value
       end
 
@@ -43,7 +49,7 @@ module RestClient
 
       jar = HTTP::CookieJar.new
       headers.fetch(:set_cookie, []).each do |cookie|
-        jar.parse(cookie, @args.fetch(:url))
+        jar.parse(cookie, @request.url)
       end
 
       @cookie_jar = jar
@@ -85,7 +91,7 @@ module RestClient
 
       url = headers[:location]
       if url !~ /^http/
-        url = URI.parse(args[:url]).merge(url).to_s
+        url = URI.parse(request.url).merge(url).to_s
       end
       new_args[:url] = url
       if request

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -1,4 +1,5 @@
 require 'cgi'
+require 'http-cookie'
 
 module RestClient
 
@@ -24,9 +25,28 @@ module RestClient
 
     # Hash of cookies extracted from response headers
     def cookies
-      @cookies ||= (self.headers[:set_cookie] || {}).inject({}) do |out, cookie_content|
-        out.merge parse_cookie(cookie_content)
+      hash = {}
+
+      cookie_jar.cookies.each do |out, cookie|
+        hash[cookie.name] = cookie.value
       end
+
+      hash
+    end
+
+    # Cookie jar extracted from response headers.
+    #
+    # @return [HTTP::CookieJar]
+    #
+    def cookie_jar
+      return @cookie_jar if @cookie_jar
+
+      jar = HTTP::CookieJar.new
+      headers.fetch(:set_cookie, []).each do |cookie|
+        jar.parse(cookie, @args.fetch(:url))
+      end
+
+      @cookie_jar = jar
     end
 
     # Return the default behavior corresponding to the response code:
@@ -61,25 +81,28 @@ module RestClient
 
     # Follow a redirection
     def follow_redirection request = nil, result = nil, & block
+      new_args = @args.dup
+
       url = headers[:location]
       if url !~ /^http/
         url = URI.parse(args[:url]).merge(url).to_s
       end
-      args[:url] = url
+      new_args[:url] = url
       if request
         if request.max_redirects == 0
           raise MaxRedirectsReached
         end
-        args[:password] = request.password
-        args[:user] = request.user
-        args[:headers] = request.headers
-        args[:max_redirects] = request.max_redirects - 1
-        # pass any cookie set in the result
-        if result && result['set-cookie']
-          args[:headers][:cookies] = (args[:headers][:cookies] || {}).merge(parse_cookie(result['set-cookie']))
-        end
+        new_args[:password] = request.password
+        new_args[:user] = request.user
+        new_args[:headers] = request.headers
+        new_args[:max_redirects] = request.max_redirects - 1
+
+        # TODO: figure out what to do with original :cookie, :cookies values
+        new_args[:headers]['Cookie'] = HTTP::Cookie.cookie_value(
+          cookie_jar.cookies(new_args.fetch(:url)))
       end
-      Request.execute args, &block
+
+      Request.execute(new_args, &block)
     end
 
     def self.beautify_headers(headers)

--- a/lib/restclient/raw_response.rb
+++ b/lib/restclient/raw_response.rb
@@ -13,12 +13,13 @@ module RestClient
 
     include AbstractResponse
 
-    attr_reader :file
+    attr_reader :file, :request
 
-    def initialize tempfile, net_http_res, args
+    def initialize(tempfile, net_http_res, args, request)
       @net_http_res = net_http_res
       @args = args
       @file = tempfile
+      @request = request
     end
 
     def to_s

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -484,9 +484,9 @@ module RestClient
     def process_result res, & block
       if @raw_response
         # We don't decode raw requests
-        response = RawResponse.new(@tf, res, args)
+        response = RawResponse.new(@tf, res, args, self)
       else
-        response = Response.create(Request.decode(res['content-encoding'], res.body), res, args)
+        response = Response.create(Request.decode(res['content-encoding'], res.body), res, args, self)
       end
 
       if block_given?

--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -6,17 +6,14 @@ module RestClient
 
     include AbstractResponse
 
-    attr_accessor :args, :net_http_res
-
     def body
       self
     end
 
-    def self.create body, net_http_res, args
+    def self.create body, net_http_res, args, request
       result = body || ''
       result.extend Response
-      result.net_http_res = net_http_res
-      result.args = args
+      result.response_set_vars(net_http_res, args, request)
       result
     end
 

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry-doc')
   s.add_development_dependency('rdoc', '>= 2.4.2', '< 5.0')
 
+  s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
   s.add_dependency('mime-types', '>= 1.16', '< 3.0')
   s.add_dependency('netrc', '~> 0.7')
 

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -8,16 +8,18 @@ describe RestClient::AbstractResponse do
 
     attr_accessor :size
 
-    def initialize net_http_res, args
+    def initialize net_http_res, args, request
       @net_http_res = net_http_res
       @args = args
+      @request = request
     end
 
   end
 
   before do
     @net_http_res = double('net http response')
-    @response = MyAbstractResponse.new(@net_http_res, {})
+    @request = double('restclient request', :url => 'http://example.com')
+    @response = MyAbstractResponse.new(@net_http_res, {}, @request)
   end
 
   it "fetches the numeric response code" do
@@ -53,7 +55,8 @@ describe RestClient::AbstractResponse do
 
   it "extract strange cookies" do
     @net_http_res.should_receive(:to_hash).and_return('set-cookie' => ['session_id=ZJ/HQVH6YE+rVkTpn0zvTQ==; path=/'])
-    @response.cookies.should eq({ 'session_id' => 'ZJ%2FHQVH6YE+rVkTpn0zvTQ%3D%3D' })
+    @response.headers.should eq({:set_cookie => ['session_id=ZJ/HQVH6YE+rVkTpn0zvTQ==; path=/']})
+    @response.cookies.should eq({ 'session_id' => 'ZJ/HQVH6YE+rVkTpn0zvTQ==' })
   end
 
   it "doesn't escape cookies" do

--- a/spec/unit/raw_response_spec.rb
+++ b/spec/unit/raw_response_spec.rb
@@ -4,7 +4,8 @@ describe RestClient::RawResponse do
   before do
     @tf = double("Tempfile", :read => "the answer is 42", :open => true)
     @net_http_res = double('net http response')
-    @response = RestClient::RawResponse.new(@tf, @net_http_res, {})
+    @request = double('http request')
+    @response = RestClient::RawResponse.new(@tf, @net_http_res, {}, @request)
   end
 
   it "behaves like string" do


### PR DESCRIPTION
Change the cookie parsing behavior to actually parse cookies according to RFC
standards. This also fixes cookie behavior on redirects.