### PR TITLE
Handle multiple header values in responses.

### DIFF
--- a/history.md
+++ b/history.md
@@ -25,6 +25,9 @@ This release is largely API compatible, but makes several breaking changes.
   warning for now
 - `Response#to_i` will now behave like `String#to_i` instead of returning the
   HTTP response code, which was very surprising behavior.
+- Handle multiple HTTP response headers with the same name (except for
+  Set-Cookie, which is special) by joining the values with a comma space,
+  compliant with RFC 7230
 
 # 1.8.0
 

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -116,9 +116,38 @@ module RestClient
       Request.execute(new_args, &block)
     end
 
+    # Convert headers hash into canonical form.
+    #
+    # Header names will be converted to lowercase symbols with underscores
+    # instead of hyphens.
+    #
+    # Headers specified multiple times will be joined by comma and space,
+    # except for Set-Cookie, which will always be an array.
+    #
+    # Per RFC 2616, if a server sends multiple headers with the same key, they
+    # MUST be able to be joined into a single header by a comma. However,
+    # Set-Cookie (RFC 6265) cannot because commas are valid within cookie
+    # definitions. The newer RFC 7230 notes (3.2.2) that Set-Cookie should be
+    # handled as a special case.
+    #
+    # http://tools.ietf.org/html/rfc2616#section-4.2
+    # http://tools.ietf.org/html/rfc7230#section-3.2.2
+    # http://tools.ietf.org/html/rfc6265
+    #
+    # @param headers [Hash]
+    # @return [Hash]
+    #
     def self.beautify_headers(headers)
       headers.inject({}) do |out, (key, value)|
-        out[key.gsub(/-/, '_').downcase.to_sym] = %w{ set-cookie }.include?(key.downcase) ? value : value.first
+        key_sym = key.gsub(/-/, '_').downcase.to_sym
+
+        # Handle Set-Cookie specially since it cannot be joined by comma.
+        if key.downcase == 'set-cookie'
+          out[key_sym] = value
+        else
+          out[key_sym] = value.join(', ')
+        end
+
         out
       end
     end

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -33,14 +33,28 @@ describe RestClient::AbstractResponse do
     @response.description.should eq "200 OK | application/pdf  bytes\n"
   end
 
-  it "beautifies the headers by turning the keys to symbols" do
-    h = RestClient::AbstractResponse.beautify_headers('content-type' => [ 'x' ])
-    h.keys.first.should eq :content_type
-  end
+  describe '.beautify_headers' do
+    it "beautifies the headers by turning the keys to symbols" do
+      h = RestClient::AbstractResponse.beautify_headers('content-type' => [ 'x' ])
+      h.keys.first.should eq :content_type
+    end
 
-  it "beautifies the headers by turning the values to strings instead of one-element arrays" do
-    h = RestClient::AbstractResponse.beautify_headers('x' => [ 'text/html' ] )
-    h.values.first.should eq 'text/html'
+    it "beautifies the headers by turning the values to strings instead of one-element arrays" do
+      h = RestClient::AbstractResponse.beautify_headers('x' => [ 'text/html' ] )
+      h.values.first.should eq 'text/html'
+    end
+
+    it 'joins multiple header values by comma' do
+      RestClient::AbstractResponse.beautify_headers(
+        {'My-Header' => ['one', 'two']}
+      ).should eq({:my_header => 'one, two'})
+    end
+
+    it 'leaves set-cookie headers as array' do
+      RestClient::AbstractResponse.beautify_headers(
+        {'Set-Cookie' => ['cookie1=foo', 'cookie2=bar']}
+      ).should eq({:set_cookie => ['cookie1=foo', 'cookie2=bar']})
+    end
   end
 
   it "fetches the headers" do

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -20,9 +20,21 @@ describe RestClient::Response, :include_helpers do
     RestClient::Response.create(nil, @net_http_res, {}, @request).to_s.should eq ""
   end
 
-  it "test headers and raw headers" do
-    @response.raw_headers["Status"][0].should eq "200 OK"
-    @response.headers[:status].should eq "200 OK"
+  describe 'header processing' do
+    it "test headers and raw headers" do
+      @response.raw_headers["Status"][0].should eq "200 OK"
+      @response.headers[:status].should eq "200 OK"
+    end
+
+    it 'handles multiple headers by joining with comma' do
+      @net_http_res = double('net http response', :to_hash => {'My-Header' => ['foo', 'bar']}, :code => 200)
+      @example_url = 'http://example.com'
+      @request = double('http request', :user => nil, :password => nil, :url => @example_url)
+      @response = RestClient::Response.create('abc', @net_http_res, {}, @request)
+
+      @response.raw_headers['My-Header'].should eq ['foo', 'bar']
+      @response.headers[:my_header].should eq 'foo, bar'
+    end
   end
 
   describe "cookie processing" do


### PR DESCRIPTION
Except for Set-Cookie, which is a special case [1], handle multiple
headers with the same key by joining their values with a comma space.

[1] http://tools.ietf.org/html/rfc7230#section-3.2.2

TODO notes:
- [x] Investigate RFC cookie / header behavior
- [x] Add tests
- [x] Add history.md notes