### PR TITLE
'rest_client' to 'rest-client'

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -32,7 +32,7 @@ dependencies for you.
 
 == Usage: Raw URL
 
-  require 'rest_client'
+  require 'rest-client'
 
   RestClient.get 'http://example.com/resource'
 


### PR DESCRIPTION
I get a warning that the 'rest_client' gem is deprecated and will be removed--my intuition is that this is a typo.