### PR TITLE
[Bug] Netrc and Basic Auth overwrites existing Authorization header

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -496,7 +496,7 @@ module RestClient
     end
 
     def setup_credentials(req)
-      req.basic_auth(user, password) if user
+      req.basic_auth(user, password) if user && !headers.has_key?("Authorization")
     end
 
     def fetch_body(http_response)

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -338,6 +338,15 @@ describe RestClient::Request, :include_helpers do
       req.should_receive(:basic_auth).with('joe', 'mypass')
       @request.setup_credentials(req)
     end
+
+    it "does not attempt to send credentials if Authorization header is set" do
+      @request.headers['Authorization'] = 'Token abc123'
+      @request.stub(:user).and_return('joe')
+      @request.stub(:password).and_return('mypass')
+      req = double("request")
+      req.should_not_receive(:basic_auth)
+      @request.setup_credentials(req)
+    end
   end
 
   it "catches EOFError and shows the more informative ServerBrokeConnection" do


### PR DESCRIPTION
Having host credentials in `.netrc` should not overwrite the `Authorization` header that's explicitly set by the developer.  For example, if my `.netrc` has the following:

    machine api.fury.io
      login michael
      password guest123

RestClient will send `Authorization: Basic <Netrc credentials>` instead of `Token abc123`:

    headers = {  'Authorization' => 'Token abc123' }
    request = RestClient::Request.new(:url => 'https://api.fury.io/users/me', :headers => headers, :method => :get)
    request.execute

Others have faced this problem and had to hack around it: https://github.com/solvebio/solvebio-ruby/blob/master/lib/solvebio/client.rb#L6
