### PR TITLE
Configurable proxy override per-request

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -32,6 +32,8 @@ module RestClient
   # * :ssl_version specifies the SSL version for the underlying Net::HTTP connection
   # * :ssl_ciphers sets SSL ciphers for the connection. See
   #     OpenSSL::SSL::SSLContext#ciphers=
+  # * :proxy override RestClient.proxy with different proxy details, or pass
+  #     false to disable proxy.
   class Request
 
     # TODO: rename timeout to read_timeout
@@ -39,7 +41,7 @@ module RestClient
     attr_reader :method, :url, :headers, :cookies,
                 :payload, :user, :password, :read_timeout, :max_redirects,
                 :open_timeout, :raw_response, :processed_headers, :args,
-                :ssl_opts
+                :ssl_opts, :proxy
 
     def self.execute(args, & block)
       new(args).execute(& block)
@@ -117,6 +119,7 @@ module RestClient
       @payload = Payload.generate(args[:payload])
       @user = args[:user]
       @password = args[:password]
+      @proxy = args[:proxy]
       if args.include?(:timeout)
         warn('Deprecated: please use `:read_timeout` instead of `:timeout`')
         @read_timeout = args[:timeout]
@@ -260,9 +263,17 @@ module RestClient
       ! Regexp.new('[\x0-\x1f\x7f,;]').match(value)
     end
 
+    def net_http_proxy
+      if proxy.nil?
+        RestClient.proxy
+      else
+        proxy
+      end
+    end
+
     def net_http_class
-      if RestClient.proxy
-        proxy_uri = URI.parse(RestClient.proxy)
+      if net_http_proxy
+        proxy_uri = URI.parse(net_http_proxy)
         Net::HTTP::Proxy(proxy_uri.hostname, proxy_uri.port, proxy_uri.user, proxy_uri.password)
       else
         Net::HTTP

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -417,6 +417,17 @@ describe RestClient::Request, :include_helpers do
     it "creates a non-proxy class if a proxy url is not given" do
       @request.net_http_class.proxy_class?.should be_falsey
     end
+
+    it "creates a proxy class if a proxy option is given" do
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :proxy => "http://example.com")
+      @request.net_http_class.proxy_class?.should be true
+    end
+
+    it "ignores the proxy with proxy option set false" do
+      RestClient.stub(:proxy).and_return("http://example.com/")
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :proxy => false)
+      @request.net_http_class.proxy_class?.should be false
+    end
   end
 
 


### PR DESCRIPTION
Allows the proxy setting to be overridden per-request.

This is mainly useful when combined with RestClient::Resource and selective endpoints which must be reached via a proxy. We're using this in combination with QuotaGuard Static, for instance, for a IP-whitelisted API.

```ruby
EXAMPLE_API = RestClient::Resource.new("http://example.com/api", proxy: ENV["QUOTAGUARDSTATIC_URL"])
```