### PR TITLE
Add support for socks proxy through Socksify gem

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -3,6 +3,7 @@ require 'mime/types'
 require 'cgi'
 require 'netrc'
 require 'set'
+require 'socksify/http'
 
 module RestClient
   # This class is used internally by RestClient to send the request, but you can also
@@ -263,7 +264,14 @@ module RestClient
     def net_http_class
       if RestClient.proxy
         proxy_uri = URI.parse(RestClient.proxy)
-        Net::HTTP::Proxy(proxy_uri.hostname, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+        case proxy_uri.scheme
+        when /^https?$/i
+          Net::HTTP::Proxy(proxy_uri.hostname, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+        when /^socks5?$/i
+          Net::HTTP.SOCKSProxy(proxy_uri.hostname, proxy_uri.port)
+        else
+          raise URI::InvalidURIError, "Unsupported proxy URI: #{RestClient.proxy}"
+        end
       else
         Net::HTTP
       end

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
   s.add_dependency('mime-types', '>= 1.16', '< 3.0')
   s.add_dependency('netrc', '~> 0.8')
+  s.add_dependency('socksify', '>= 1.6.0', '< 2.0')
 
   s.required_ruby_version = '>= 1.9.3'
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -414,6 +414,18 @@ describe RestClient::Request, :include_helpers do
       @request.net_http_class.proxy_address.should == "::1"
     end
 
+    it "creates a socks proxy class if proxy's scheme is socks(5)" do
+      RestClient.stub(:proxy).and_return("socks5://localhost:8080")
+      @request.net_http_class.respond_to?(:socks_server).should be true
+    end
+
+    it "throws error if the URI's scheme is unsupported" do
+      lambda {
+        RestClient.stub(:proxy).and_return("ftp://example.com")
+        @request.net_http_class
+      }.should raise_error(URI::InvalidURIError)
+    end
+
     it "creates a non-proxy class if a proxy url is not given" do
       @request.net_http_class.proxy_class?.should be_falsey
     end


### PR DESCRIPTION
Adding supports for Socks proxy through [Socksify gem](http://socksify.rubyforge.org/)

Also limits the supported scheme to http, https, socks and socks5.
An unsupported proxy URI will cause an error to be thrown.