### PR TITLE
Fix use of log when response encoding error

### DIFF
--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -29,7 +29,7 @@ module RestClient
       begin
         encoding = Encoding.find(charset) if charset
       rescue ArgumentError
-        RestClient.log "No such encoding: #{charset.inspect}"
+        RestClient.log << "No such encoding: #{charset.inspect}"
       end
 
       return unless encoding


### PR DESCRIPTION
I've been getting exceptions like:

```
RestClient.get "http://example.com"
# => 200 OK | text/html 2726 bytes
ArgumentError: wrong number of arguments (1 for 0)
	from /Users/sj26/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/rest-client-4e3491f2f405/lib/restclient.rb:145:in `log'
	from /Users/sj26/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/rest-client-4e3491f2f405/lib/restclient/response.rb:32:in `rescue in fix_encoding'
	from /Users/sj26/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/rest-client-4e3491f2f405/lib/restclient/response.rb:29:in `fix_encoding'
```

Which turns out to be due to an error when logging an invalid encoding. So here's a patch to fix it.