### PR TITLE
Store redirection history on response objects.

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -7,6 +7,10 @@ module RestClient
 
     attr_reader :net_http_res, :args, :request
 
+    def inspect
+      raise NotImplementedError.new('must override in subclass')
+    end
+
     # HTTP status code
     def code
       @code ||= @net_http_res.code.to_i

--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -210,12 +210,6 @@ module RestClient
     end
   end
 
-  class MaxRedirectsReached < Exception
-    def message
-      'Maximum number of redirect reached'
-    end
-  end
-
   # The server broke the connection prior to the request completing.  Usually
   # this means it crashed, or sometimes that your network connection was
   # severed before it could complete.

--- a/lib/restclient/raw_response.rb
+++ b/lib/restclient/raw_response.rb
@@ -15,6 +15,10 @@ module RestClient
 
     attr_reader :file, :request
 
+    def inspect
+      "<RestClient::RawResponse @code=#{code.inspect}, @file=#{file.inspect}, @request=#{request.inspect}>"
+    end
+
     def initialize(tempfile, net_http_res, args, request)
       @net_http_res = net_http_res
       @args = args

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -556,13 +556,14 @@ module RestClient
         # We don't decode raw requests
         response = RawResponse.new(@tf, res, args, self)
       else
-        response = Response.create(Request.decode(res['content-encoding'], res.body), res, args, self)
+        decoded = Request.decode(res['content-encoding'], res.body)
+        response = Response.create(decoded, res, args, self)
       end
 
       if block_given?
         block.call(response, self, res, & block)
       else
-        response.return!(self, res, & block)
+        response.return!(&block)
       end
 
     end

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -42,6 +42,9 @@ module RestClient
                 :open_timeout, :raw_response, :processed_headers, :args,
                 :ssl_opts
 
+    # An array of previous redirection responses
+    attr_accessor :redirection_history
+
     def self.execute(args, & block)
       new(args).execute(& block)
     end

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -109,6 +109,10 @@ module RestClient
     SSLOptionList = %w{client_cert client_key ca_file ca_path cert_store
                        version ciphers verify_callback verify_callback_warnings}
 
+    def inspect
+      "<RestClient::Request @method=#{@method.inspect}, @url=#{@url.inspect}>"
+    end
+
     def initialize args
       @method = args[:method] or raise ArgumentError, "must pass :method"
       @headers = (args[:headers] || {}).dup

--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -6,8 +6,36 @@ module RestClient
 
     include AbstractResponse
 
+    # Return the HTTP response body.
+    #
+    # Future versions of RestClient will deprecate treating response objects
+    # directly as strings, so it will be necessary to call `.body`.
+    #
+    # @return [String]
+    #
     def body
-      @body ||= String.new(self)
+      # Benchmarking suggests that "#{self}" is fastest, and that caching the
+      # body string in an instance variable doesn't make it enough faster to be
+      # worth the extra memory storage.
+      String.new(self)
+    end
+
+    # Convert the HTTP response body to a pure String object.
+    #
+    # @return [String]
+    def to_s
+      body
+    end
+
+    # Convert the HTTP response body to a pure String object.
+    #
+    # @return [String]
+    def to_str
+      body
+    end
+
+    def inspect
+      "<RestClient::Response #{code.inspect} #{body_truncated(10).inspect}>"
     end
 
     def self.create body, net_http_res, args, request
@@ -37,6 +65,14 @@ module RestClient
       response.force_encoding(encoding)
 
       response
+    end
+
+    def body_truncated(length)
+      if body.length > length
+        body[0..length] + '...'
+      else
+        body
+      end
     end
   end
 end

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -73,8 +73,8 @@ describe RestClient::Response, :include_helpers do
     it "should return itself for normal codes" do
       (200..206).each do |code|
         net_http_res = response_double(:code => '200')
-        response = RestClient::Response.create('abc', net_http_res, {}, @request)
-        response.return! @request
+        resp = RestClient::Response.create('abc', net_http_res, {}, @request)
+        resp.return!
       end
     end
 
@@ -82,8 +82,8 @@ describe RestClient::Response, :include_helpers do
       RestClient::Exceptions::EXCEPTIONS_MAP.each_key do |code|
         unless (200..207).include? code
           net_http_res = response_double(:code => code.to_i)
-          response = RestClient::Response.create('abc', net_http_res, {}, @request)
-          lambda { response.return!}.should raise_error
+          resp = RestClient::Response.create('abc', net_http_res, {}, @request)
+          lambda { resp.return! }.should raise_error
         end
       end
     end
@@ -118,26 +118,38 @@ describe RestClient::Response, :include_helpers do
 
     it "doesn't follow a 301 when the request is a post" do
       net_http_res = response_double(:code => 301)
-      response = RestClient::Response.create('abc', net_http_res, {:method => :post}, @request)
-      lambda { response.return!(@request)}.should raise_error(RestClient::MovedPermanently)
+      response = RestClient::Response.create('abc', net_http_res,
+                                             {:method => :post}, @request)
+      lambda {
+        response.return!
+      }.should raise_error(RestClient::MovedPermanently)
     end
 
     it "doesn't follow a 302 when the request is a post" do
       net_http_res = response_double(:code => 302)
-      response = RestClient::Response.create('abc', net_http_res, {:method => :post}, @request)
-      lambda { response.return!(@request)}.should raise_error(RestClient::Found)
+      response = RestClient::Response.create('abc', net_http_res,
+                                             {:method => :post}, @request)
+      lambda {
+        response.return!
+      }.should raise_error(RestClient::Found)
     end
 
     it "doesn't follow a 307 when the request is a post" do
       net_http_res = response_double(:code => 307)
-      response = RestClient::Response.create('abc', net_http_res, {:method => :post}, @request)
-      lambda { response.return!(@request)}.should raise_error(RestClient::TemporaryRedirect)
+      response = RestClient::Response.create('abc', net_http_res,
+                                             {:method => :post}, @request)
+      lambda {
+        response.return!
+      }.should raise_error(RestClient::TemporaryRedirect)
     end
 
     it "doesn't follow a redirection when the request is a put" do
       net_http_res = response_double(:code => 301)
-      response = RestClient::Response.create('abc', net_http_res, {:method => :put}, @request)
-      lambda { response.return!(@request)}.should raise_error(RestClient::MovedPermanently)
+      response = RestClient::Response.create('abc', net_http_res,
+                                             {:method => :put}, @request)
+      lambda {
+        response.return!
+      }.should raise_error(RestClient::MovedPermanently)
     end
 
     it "follows a redirection when the request is a post and result is a 303" do
@@ -173,14 +185,18 @@ describe RestClient::Response, :include_helpers do
     it "follows no more than 10 redirections before raising error" do
       stub_request(:get, 'http://some/redirect-1').to_return(:body => '', :status => 301, :headers => {'Location' => 'http://some/redirect-2'})
       stub_request(:get, 'http://some/redirect-2').to_return(:body => '', :status => 301, :headers => {'Location' => 'http://some/redirect-2'})
-      lambda { RestClient::Request.execute(:url => 'http://some/redirect-1', :method => :get) }.should raise_error(RestClient::MaxRedirectsReached)
+      lambda {
+        RestClient::Request.execute(url: 'http://some/redirect-1', method: :get)
+      }.should raise_error(RestClient::MovedPermanently)
       WebMock.should have_requested(:get, 'http://some/redirect-2').times(10)
     end
 
     it "follows no more than max_redirects redirections, if specified" do
       stub_request(:get, 'http://some/redirect-1').to_return(:body => '', :status => 301, :headers => {'Location' => 'http://some/redirect-2'})
       stub_request(:get, 'http://some/redirect-2').to_return(:body => '', :status => 301, :headers => {'Location' => 'http://some/redirect-2'})
-      lambda { RestClient::Request.execute(:url => 'http://some/redirect-1', :method => :get, :max_redirects => 5) }.should raise_error(RestClient::MaxRedirectsReached)
+      lambda {
+        RestClient::Request.execute(url: 'http://some/redirect-1', method: :get, max_redirects: 5)
+      }.should raise_error(RestClient::MovedPermanently)
       WebMock.should have_requested(:get, 'http://some/redirect-2').times(5)
     end
   end


### PR DESCRIPTION
- Remove `MaxRedirectsReached`, instead raise the normal
  `ExceptionWithResponse` subclasses, such as `RestClient::MovedPermanently`.
  These exceptions will carry the wrapped response object at `.response`, which
  will now make it possible to see what actually happened when the redirection
  limit is hit.
- Refactor `AbstractResponse#return!` and `#follow_redirection`.
- Add `AbstractResponse#history`, which stores a list of responses to prior
  requests in a redirection chain. This makes it possible for callers to
  determine what the original responses and requests were for previous requests
  before following redirection.
- Add `inspect` methods to `Request` and `Response` objects. This makes it much
  easier to tell the difference between a pure `String` object and a
  `RestClient::Response` object.