### PR TITLE
Clean up exception classes.

### DIFF
--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -26,7 +26,7 @@ module RestClient
               401 => 'Unauthorized',
               402 => 'Payment Required',
               403 => 'Forbidden',
-              404 => 'Resource Not Found', # TODO: change to 'Not Found'
+              404 => 'Not Found',
               405 => 'Method Not Allowed',
               406 => 'Not Acceptable',
               407 => 'Proxy Authentication Required',
@@ -181,6 +181,8 @@ module RestClient
     Exceptions::EXCEPTIONS_MAP[code] = klass_constant
   end
 
+  # Backwards compatibility. "Not Found" is the actual text in the RFCs.
+  ResourceNotFound = NotFound
 
   # The server broke the connection prior to the request completing.  Usually
   # this means it crashed, or sometimes that your network connection was

--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -181,19 +181,6 @@ module RestClient
     Exceptions::EXCEPTIONS_MAP[code] = klass_constant
   end
 
-  # A redirect was encountered; caught by execute to retry with the new url.
-  class Redirect < Exception
-
-    def message
-      'Redirect'
-    end
-
-    attr_accessor :url
-
-    def initialize(url)
-      @url = url
-    end
-  end
 
   # The server broke the connection prior to the request completing.  Usually
   # this means it crashed, or sometimes that your network connection was

--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -66,18 +66,6 @@ module RestClient
               511 => 'Network Authentication Required', # RFC6585
   }
 
-  # Compatibility : make the Response act like a Net::HTTPResponse when needed
-  module ResponseForException
-    def method_missing symbol, *args
-      if net_http_res.respond_to? symbol
-        warn "[warning] The response contained in an RestClient::Exception is now a RestClient::Response instead of a Net::HTTPResponse, please update your code"
-        net_http_res.send symbol, *args
-      else
-        super
-      end
-    end
-  end
-
   # This is the base RestClient exception class. Rescue it if you want to
   # catch any exception that your request might raise
   # You can get the status code by e.http_code, or see anything about the
@@ -93,9 +81,6 @@ module RestClient
       @response = response
       @message = nil
       @initial_response_code = initial_response_code
-
-      # compatibility: this make the exception behave like a Net::HTTPResponse
-      response.extend ResponseForException if response
     end
 
     def http_code
@@ -226,11 +211,4 @@ module RestClient
       self.message = message
     end
   end
-end
-
-class RestClient::Request
-  # backwards compatibility
-  Redirect = RestClient::Redirect
-  Unauthorized = RestClient::Unauthorized
-  RequestFailed = RestClient::RequestFailed
 end

--- a/spec/unit/exceptions_spec.rb
+++ b/spec/unit/exceptions_spec.rb
@@ -14,7 +14,7 @@ describe RestClient::Exception do
   end
 
   it "sets the exception message to ErrorMessage" do
-    RestClient::ResourceNotFound.new.message.should eq 'Resource Not Found'
+    RestClient::ResourceNotFound.new.message.should eq 'Not Found'
   end
 
   it "contains exceptions in RestClient" do
@@ -77,5 +77,11 @@ describe RestClient::ResourceNotFound do
     rescue RestClient::ResourceNotFound => e
       e.response.body.should eq body
     end
+  end
+end
+
+describe "backwards compatibility" do
+  it 'aliases RestClient::NotFound as ResourceNotFound' do
+    RestClient::ResourceNotFound.should eq RestClient::NotFound
   end
 end

--- a/spec/unit/exceptions_spec.rb
+++ b/spec/unit/exceptions_spec.rb
@@ -67,22 +67,8 @@ describe RestClient::ResourceNotFound do
       e.response.should eq response
     end
   end
-end
 
-describe "backwards compatibility" do
-  it "alias RestClient::Request::Redirect to RestClient::Redirect" do
-    RestClient::Request::Redirect.should eq RestClient::Redirect
-  end
-
-  it "alias RestClient::Request::Unauthorized to RestClient::Unauthorized" do
-    RestClient::Request::Unauthorized.should eq RestClient::Unauthorized
-  end
-
-  it "alias RestClient::Request::RequestFailed to RestClient::RequestFailed" do
-    RestClient::Request::RequestFailed.should eq RestClient::RequestFailed
-  end
-
-  it "make the exception's response act like an Net::HTTPResponse" do
+  it 'stores the body on the response of the exception' do
     body = "body"
     stub_request(:get, "www.example.com").to_return(:body => body, :status => 404)
     begin


### PR DESCRIPTION
- Rename `RestClient::ResourceNotFound` to `RestClient::NotFound`, creating an
  alias for backwards compatibility.
- Remove a good deal of unused and long since deprecated constants that have
  been in RestClient for ages.