### PR TITLE
Support disabling the proxy by setting to falsey.

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -90,8 +90,23 @@ module RestClient
     Request.execute(:method => :options, :url => url, :headers => headers, &block)
   end
 
-  class << self
-    attr_accessor :proxy
+  # A global proxy URL to use for all requests. This can be overridden on a
+  # per-request basis by passing `:proxy` to RestClient::Request.
+  def self.proxy
+    @proxy
+  end
+  def self.proxy=(value)
+    @proxy = value
+    @proxy_set = true
+  end
+
+  # Return whether RestClient.proxy was set explicitly. We use this to
+  # differentiate between no value being set and a value explicitly set to nil.
+  #
+  # @return [Boolean]
+  #
+  def self.proxy_set?
+    !!@proxy_set
   end
 
   # Setup the log for RestClient calls.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,8 @@ RSpec.configure do |config|
 
   # add helpers
   config.include Helpers, :include_helpers
+
+  config.mock_with :rspec do |mocks|
+    mocks.yield_receiver_to_any_instance_implementation_blocks = true
+  end
 end


### PR DESCRIPTION
Newer ruby versions of Net::HTTP will use ENV['http_proxy'] directly.
You should be able to disable the proxy in RestClient without overriding
ENV['http_proxy'] directly.

Now, detect when a proxy has been explicitly set to falsey, and
explicitly create a Net::HTTP object with proxy disabled in that case.

Fixes: #230 