### PR TITLE
Escaping URI on parse

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -340,7 +340,7 @@ module RestClient
       # RFC, but specified by the URL RFC 1738.)
       # https://tools.ietf.org/html/rfc3986#section-3.1
       url = 'http://' + url unless url.match(%r{\A[a-z][a-z0-9+.-]*://}i)
-      URI.parse(url)
+      URI.parse(URI.escape(url))
     end
 
     def parse_url_with_auth(url)


### PR DESCRIPTION
Need it to deal with special symbols and non-ASCII chars in URI path.  
Example:  
```
https://ru.wikipedia.org/wiki/Кириллица
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
```