### PR TITLE
Make the Response actually a class not a module.

### DIFF
--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -2,7 +2,7 @@ module RestClient
 
   # A Response from RestClient, you can access the response body, the code or the headers.
   #
-  module Response
+  class Response < String
 
     include AbstractResponse
 
@@ -38,9 +38,8 @@ module RestClient
       "<RestClient::Response #{code.inspect} #{body_truncated(10).inspect}>"
     end
 
-    def self.create body, net_http_res, args, request
-      result = body || ''
-      result.extend Response
+    def self.create(body, net_http_res, args, request)
+      result = self.new(body || '')
 
       result.response_set_vars(net_http_res, args, request)
       fix_encoding(result)


### PR DESCRIPTION
Making Response a module was always super questionable. Removing the use
of extend should improve performance and clarity.

Fixes: #225