### PR TITLE
Add before_execution_proc support to Requests.

### DIFF
--- a/history.md
+++ b/history.md
@@ -23,13 +23,17 @@ This release is largely API compatible, but makes several breaking changes.
 - Fix some support for using IPv6 addresses in URLs (still affected by Ruby
   2.0+ bug https://bugs.ruby-lang.org/issues/9129, with the fix expected to be
   backported to 2.0 and 2.1)
-- `Response#to_i` will now behave like `String#to_i` instead of returning the
-  HTTP response code, which was very surprising behavior.
-- `Response#body` and `#to_s` will now return a true `String` object rather
-  than self. Previously there was no easy way to get the true `String` response
-  instead of the Frankenstein response string object with AbstractResponse
-  mixed in. Response objects also now implement `.inspect` to make this
-  distinction clearer.
+- `Response` objects are now a subclass of `String` rather than a `String` that
+  mixes in the response functionality. Most of the methods remain unchanged,
+  but this makes it much easier to understand what is happening when you look
+  at a RestClient response object. There are a few additional changes:
+  - Response objects now implement `.inspect` to make this distinction clearer.
+  - `Response#to_i` will now behave like `String#to_i` instead of returning the
+    HTTP response code, which was very surprising behavior.
+  - `Response#body` and `#to_s` will now return a true `String` object rather
+    than self. Previously there was no easy way to get the true `String` response
+    instead of the Frankenstein response string object with AbstractResponse
+    mixed in.
 - Handle multiple HTTP response headers with the same name (except for
   Set-Cookie, which is special) by joining the values with a comma space,
   compliant with RFC 7230

--- a/history.md
+++ b/history.md
@@ -51,6 +51,9 @@ This release is largely API compatible, but makes several breaking changes.
 - When following HTTP redirection, store a list of each previous response on
   the response object as `.history`. This makes it possible to access the
   original response headers and body before the redirection was followed.
+- Add `:before_execution_proc` option to `RestClient::Request`. This makes it
+  possible to add procs like `RestClient.add_before_execution_proc` to a single
+  request without global state.
 
 # 1.8.0
 

--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -166,6 +166,7 @@ module RestClient
   # Add a Proc to be called before each request in executed.
   # The proc parameters will be the http request and the request params.
   def self.add_before_execution_proc &proc
+    raise ArgumentError.new('block is required') unless proc
     @@before_execution_procs << proc
   end
 

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -33,6 +33,9 @@ module RestClient
   # * :ssl_version specifies the SSL version for the underlying Net::HTTP connection
   # * :ssl_ciphers sets SSL ciphers for the connection. See
   #     OpenSSL::SSL::SSLContext#ciphers=
+  # * :before_execution_proc a Proc to call before executing the request. This
+  #      proc, like procs from RestClient.before_execution_procs, will be
+  #      called with the HTTP request and request params.
   class Request
 
     # TODO: rename timeout to read_timeout
@@ -186,6 +189,8 @@ module RestClient
       @max_redirects = args[:max_redirects] || 10
       @processed_headers = make_headers headers
       @args = args
+
+      @before_execution_proc = args[:before_execution_proc]
     end
 
     def execute & block
@@ -477,6 +482,10 @@ module RestClient
 
       RestClient.before_execution_procs.each do |before_proc|
         before_proc.call(req, args)
+      end
+
+      if @before_execution_proc
+        @before_execution_proc.call(req, args)
       end
 
       log_request

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -546,7 +546,7 @@ module RestClient
         # Taken from Chef, which as in turn...
         # Stolen from http://www.ruby-forum.com/topic/166423
         # Kudos to _why!
-        @tf = Tempfile.new("rest-client")
+        @tf = Tempfile.new('rest-client.')
         @tf.binmode
         size, total = 0, http_response.header['Content-Length'].to_i
         http_response.read_body do |chunk|

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -1074,7 +1074,7 @@ describe RestClient::Request, :include_helpers do
       tempfile.should_receive(:binmode)
       tempfile.stub(:open)
       tempfile.stub(:close)
-      Tempfile.should_receive(:new).with("rest-client").and_return(tempfile)
+      Tempfile.should_receive(:new).with("rest-client.").and_return(tempfile)
 
       net_http_res = Net::HTTPOK.new(nil, "200", "body")
       net_http_res.stub(:read_body).and_return("body")


### PR DESCRIPTION
This makes it possible for individual requests to carry independent
before_execution_procs. (We're slowly getting rid of the messy global
configuration.)