### PR TITLE
Use '&' to append query params to url when url already contains params.

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -227,7 +227,7 @@ module RestClient
       end
       unless url_params.empty?
         query_string = url_params.collect { |k, v| "#{k.to_s}=#{CGI::escape(v.to_s)}" }.join('&')
-        url + "?#{query_string}"
+        url + (url.include?('?') ? '&' : '?') + "#{query_string}"
       else
         url
       end

--- a/spec/unit/request2_spec.rb
+++ b/spec/unit/request2_spec.rb
@@ -8,6 +8,9 @@ describe RestClient::Request do
 
     stub_request(:get, 'http://some/resource').with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar', 'params' => 'a'}).to_return(:body => 'foo', :status => 200)
     RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :headers => {:foo => :bar, :params => :a}).body.should eq 'foo'
+
+    stub_request(:get, 'http://some/resource?z=x&a=b&c=d&').with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar'}).to_return(:body => 'foo', :status => 200)
+    RestClient::Request.execute(:url => 'http://some/resource?z=x', :method => :get, :headers => {:foo => :bar, :params => {:a => :b, 'c' => 'd'}}).body.should eq 'foo'
   end
 
   it "can use a block to process response" do


### PR DESCRIPTION
If this is not the desired behavior, then maybe an exception should be raised when both a url that contains params and query params are passed to rest-client.