### PR TITLE
Run Travis tests on OS X as well as Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+os:
+  - linux
+  - osx
 rvm:
   - "1.9.3"
   - "2.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,12 @@ script:
 branches:
   except:
     - "readme-edits"
+
+# These versions do not yet work on OS X on Travis
+# (last tested: 2015-09)
+matrix:
+  exclude:
+    - os: osx
+      rvm: 'jruby-19mode'
+    - os: osx
+      rvm: '2.2'


### PR DESCRIPTION
The rest-client repo is gated into the Travis OS X beta.

http://docs.travis-ci.com/user/multi-os/