### PR TITLE
Keep existing cookies after redirect

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -233,24 +233,33 @@ module RestClient
       end
     end
 
-    def make_headers user_headers
-      unless @cookies.empty?
+    def cookie_jar
+      return @cookie_jar if @cookie_jar
 
-        # Validate that the cookie names and values look sane. If you really
-        # want to pass scary characters, just set the Cookie header directly.
-        # RFC6265 is actually much more restrictive than we are.
-        @cookies.each do |key, val|
-          unless valid_cookie_key?(key)
-            raise ArgumentError.new("Invalid cookie name: #{key.inspect}")
-          end
-          unless valid_cookie_value?(val)
-            raise ArgumentError.new("Invalid cookie value: #{val.inspect}")
-          end
+      @cookie_jar = HTTP::CookieJar.new
+
+      return @cookie_jar unless parsed_url
+
+      (@cookies || {}).each do |key, value|
+        unless valid_cookie_key?(key)
+          raise ArgumentError.new("Invalid cookie name: #{key.inspect}")
         end
 
-        user_headers = user_headers.dup
-        user_headers[:cookie] = @cookies.map { |key, val| "#{key}=#{val}" }.sort.join('; ')
+        unless valid_cookie_value?(value)
+          raise ArgumentError.new("Invalid cookie value: #{value.inspect}")
+        end
+
+        @cookie_jar.parse("#{key}=#{value}", parsed_url)
       end
+
+      @cookie_jar
+    end
+
+    def make_headers user_headers
+      unless cookie_jar.empty?
+        user_headers[:cookie] = HTTP::Cookie.cookie_value(cookie_jar.cookies(parsed_url))
+      end
+
       headers = stringify_headers(default_headers).merge(stringify_headers(user_headers))
       headers.merge!(@payload.headers) if @payload
       headers
@@ -271,9 +280,9 @@ module RestClient
     end
 
     # Validate cookie values. Rather than following RFC 6265, allow anything
-    # but control characters, comma, and semicolon.
+    # but control characters. Semicolon is allowed for passing options.
     def valid_cookie_value?(value)
-      ! Regexp.new('[\x0-\x1f\x7f,;]').match(value)
+      ! Regexp.new('[\x0-\x1f\x7f]').match(value)
     end
 
     # The proxy URI for this request. If `:proxy` was provided on this request,
@@ -682,6 +691,15 @@ module RestClient
     end
 
     private
+
+    def parsed_url
+      return @parsed_url if @parsed_url
+
+      begin
+        @parsed_url = parse_url(url)
+      rescue URI::InvalidURIError
+      end
+    end
 
     def parser
       URI.const_defined?(:Parser) ? URI::Parser.new : URI

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -124,7 +124,13 @@ module RestClient
       else
         raise ArgumentError, "must pass :url"
       end
+      @cookie_jar = @headers.delete(:cookie_jar) || args[:cookie_jar]
       @cookies = @headers.delete(:cookies) || args[:cookies] || {}
+
+      if @cookie_jar && !@cookies.empty?
+        raise ArgumentError, "can't pass :cookie_jar and :cookies together"
+      end
+
       @payload = Payload.generate(args[:payload])
       @user = args[:user]
       @password = args[:password]

--- a/spec/integration/httpbin_spec.rb
+++ b/spec/integration/httpbin_spec.rb
@@ -68,5 +68,16 @@ describe RestClient::Request do
         ex.response.cookies['foo'].should eq '"bar:baz"'
       }
     end
+
+    it 'keeps original cookies for the domain' do
+      response = execute_httpbin('cookies/set?foo=bar', method: :get, cookies: { baz: 'quux; Path=/' })
+      response.cookies['foo'].should eq 'bar'
+      response.cookies['baz'].should eq 'quux'
+    end
+
+    it 'overwrites original cookies with new cookies if present' do
+      response = execute_httpbin('cookies/set?foo=bar', method: :get, cookies: { foo: 'quux; Path=/' })
+      response.cookies['foo'].should eq 'bar'
+    end
   end
 end

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -18,7 +18,7 @@ describe RestClient::AbstractResponse do
 
   before do
     @net_http_res = double('net http response')
-    @request = double('restclient request', :url => 'http://example.com')
+    @request = double('restclient request', :url => 'http://example.com', :cookie_jar => HTTP::CookieJar.new)
     @response = MyAbstractResponse.new(@net_http_res, {}, @request)
   end
 

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -1128,4 +1128,25 @@ describe RestClient::Request, :include_helpers do
       @request.execute
     end
   end
+
+  describe 'constructor' do
+    it 'requires a method' do
+      lambda {
+        RestClient::Request.new :cookies => { 'foo' => 'bar' }
+      }.should raise_error(ArgumentError, /:method/)
+    end
+
+    it 'requires a URL' do
+      lambda {
+        RestClient::Request.new :method => 'GET'
+      }.should raise_error(ArgumentError, /:url/)
+    end
+
+    it 'forbids :cookies and :cookie_jar to be set' do
+      lambda {
+        RestClient::Request.new :method => 'GET', :url => 'http://example.com',
+                                :cookie_jar => HTTP::CookieJar.new, :headers => { :cookies => { 'foo' => 'bar' } }
+      }.should raise_error(ArgumentError, /:cookie_jar and :cookies/)
+    end
+  end
 end

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -4,7 +4,7 @@ describe RestClient::Response, :include_helpers do
   before do
     @net_http_res = double('net http response', :to_hash => {"Status" => ["200 OK"]}, :code => 200)
     @example_url = 'http://example.com'
-    @request = double('http request', :user => nil, :password => nil, :url => @example_url, :redirection_history => nil)
+    @request = double('http request', :user => nil, :password => nil, :url => @example_url, :redirection_history => nil, :cookie_jar => HTTP::CookieJar.new)
     @response = RestClient::Response.create('abc', @net_http_res, {}, @request)
   end
 


### PR DESCRIPTION
This is a quick implementation of the idea in #406, to allow a cookie jar for requests. We can then re-use this cookie jar when following redirects so that any applicable cookies from previous requests can be sent to any new endpoints, like a browser would.

There are quite a lot of ways to pass cookies already, so I was wary of adding another. I've tried to keep this as simple as possible but that didn't work out too well :smiley: