### PR TITLE
Append GET params with & when adding more.

### DIFF
--- a/history.md
+++ b/history.md
@@ -67,6 +67,7 @@ This release is largely API compatible, but makes several breaking changes.
 - Run tests on Travis's beta OS X support.
 - Make `Request#transmit` a private method, along with a few others.
 - Refactor URI parsing to happen earlier, in Request initialization.
+- When adding URL params, handle URLs that already contain params.
 
 # 2.0.0.rc1
 

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -236,9 +236,14 @@ module RestClient
           false
         end
       end
+
       unless url_params.empty?
         query_string = url_params.collect { |k, v| "#{k.to_s}=#{CGI::escape(v.to_s)}" }.join('&')
-        url + "?#{query_string}"
+        if url.include?('?')
+          url + '&' + query_string
+        else
+          url + '?' + query_string
+        end
       else
         url
       end

--- a/spec/unit/request2_spec.rb
+++ b/spec/unit/request2_spec.rb
@@ -2,12 +2,20 @@ require_relative '_lib'
 
 describe RestClient::Request do
 
-  it "manage params for get requests" do
-    stub_request(:get, 'http://some/resource?a=b&c=d').with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar'}).to_return(:body => 'foo', :status => 200)
-    RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :headers => {:foo => :bar, :params => {:a => :b, 'c' => 'd'}}).body.should eq 'foo'
+  context 'params for GET requests' do
+    it "manage params for get requests" do
+      stub_request(:get, 'http://some/resource?a=b&c=d').with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar'}).to_return(:body => 'foo', :status => 200)
+      RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :headers => {:foo => :bar, :params => {:a => :b, 'c' => 'd'}}).body.should eq 'foo'
 
-    stub_request(:get, 'http://some/resource').with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar', 'params' => 'a'}).to_return(:body => 'foo', :status => 200)
-    RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :headers => {:foo => :bar, :params => :a}).body.should eq 'foo'
+      stub_request(:get, 'http://some/resource').with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar'}).to_return(:body => 'foo', :status => 200)
+      RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :headers => {:foo => :bar, :params => :a}).body.should eq 'foo'
+    end
+
+    it 'adds GET params when params are present in URL' do
+      stub_request(:get, 'http://some/resource?a=b&c=d').with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Foo'=>'bar'}).to_return(:body => 'foo', :status => 200)
+      RestClient::Request.execute(:url => 'http://some/resource?a=b', :method => :get, :headers => {:foo => :bar, :params => {:c => 'd'}}).body.should eq 'foo'
+    end
+
   end
 
   it "can use a block to process response" do

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -1140,4 +1140,23 @@ describe RestClient::Request, :include_helpers do
       }.should raise_error(URI::InvalidURIError)
     end
   end
+
+  describe 'process_url_params' do
+    it 'should handle basic URL params' do
+      @request.process_url_params('https://example.com/foo', params: {key1: 123, key2: 'abc'}).
+        should eq 'https://example.com/foo?key1=123&key2=abc'
+
+      @request.process_url_params('https://example.com/foo', params: {'key1' => 123}).
+        should eq 'https://example.com/foo?key1=123'
+
+      @request.process_url_params('https://example.com/path',
+                                  params: {foo: 'one two', bar: 'three + four == seven'}).
+        should eq 'https://example.com/path?foo=one+two&bar=three+%2B+four+%3D%3D+seven'
+    end
+
+    it 'should combine with & when URL params already exist' do
+      @request.process_url_params('https://example.com/path?foo=1', params: {bar: 2}).
+        should eq 'https://example.com/path?foo=1&bar=2'
+    end
+  end
 end


### PR DESCRIPTION
If there is already a '?' in the URL, add additional query params using
'&' instead.

Ideally we would be more clever about this and actually take the URL
into parts and then unparse in a structured way rather than just blindly
appending, but oh well.

Fixes: #402, #96