### PR TITLE
Specs pass with mime-types 3

### DIFF
--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~> 0')
 
   s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
-  s.add_dependency('mime-types', '>= 1.16', '< 3.0')
+  s.add_dependency('mime-types', '>= 1.16', '< 4.0')
   s.add_dependency('netrc', '~> 0.8')
 
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
The specs pass with mime-types version 3; as long as users still using Ruby 1.9
manually restrict mime-types to < 3 in their Gemfile, they will be just fine.