### PR TITLE
Allow IO-like objects for multipart payloads

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -122,10 +122,10 @@ Yeah, that's right!  This does multipart sends for you!
 
 This does two things for you:
 
-* Auto-detects that you have a File value sends it as multipart
-* Auto-detects the mime of the file and sets it in the HEAD of the payload for each entry
+* Auto-detects that you have an IO-like value sends it as multipart
+* Auto-detects the mime of the IO and sets it in the HEAD of the payload for each entry
 
-If you are sending params that do not contain a File object but the payload needs to be multipart then:
+If you are sending params that do not contain a IO-like object but the payload needs to be multipart then:
 
   RestClient.post '/data', {:foo => 'bar', :multipart => true}
 

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,3 +1,6 @@
+require "stringio"
+require "forwardable"
+
 module Helpers
   def response_double(opts={})
     double('response', {:to_hash => {}}.merge(opts))
@@ -11,4 +14,13 @@ module Helpers
   ensure
     $stderr = original_stderr
   end
+end
+
+class FakeIO
+  def initialize(content)
+    @io = StringIO.new(content)
+  end
+
+  extend Forwardable
+  delegate [:read, :size, :rewind, :eof?, :close] => :@io
 end

--- a/spec/unit/payload_spec.rb
+++ b/spec/unit/payload_spec.rb
@@ -167,6 +167,18 @@ Content-Type: text/plain\r
       EOS
     end
 
+    it "should accept an IO-like object" do
+      io = FakeIO.new("content")
+      m = RestClient::Payload::Multipart.new({:foo => io})
+      m.to_s.should eq <<-EOS
+--#{m.boundary}\r
+Content-Disposition: form-data; name="foo"; filename="rest-client"\r
+Content-Type: text/plain\r
+\r
+content\r
+--#{m.boundary}--\r
+      EOS
+    end
   end
 
   context "streamed payloads" do


### PR DESCRIPTION
The input object doesn't have to be an actual file, it can be just an IO-like object. This is useful in projects like [Refile](https://github.com/refile/refile) and [Shrine](https://github.com/janko-m/shrine), which don't accept only files but any IO object.

Internally it only needs to respond to `#read(*args)`, but I've made the `FakeIO` test object with the 5 methods because we may need them in the future (these are enough for object to be IO-like, we've determined that in Refile and Shrine), so it's good to have a bit wider contract than just `#read`.

I've needed this when building a shrine-cloudinary storage for Shrine, because the Cloudinary gem internally uses rest-client.