### PR TITLE
add count_time option, to count response time

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -41,10 +41,10 @@ module RestClient
     attr_reader :method, :uri, :url, :headers, :cookies, :payload, :proxy,
                 :user, :password, :read_timeout, :max_redirects,
                 :open_timeout, :raw_response, :processed_headers, :args,
-                :ssl_opts
+                :ssl_opts, :started_at
 
     # An array of previous redirection responses
-    attr_accessor :redirection_history
+    attr_accessor :redirection_history, :finished_at
 
     def self.execute(args, & block)
       new(args).execute(& block)
@@ -115,6 +115,8 @@ module RestClient
     end
 
     def initialize args
+      @started_at = Time.now if args[:count_time]
+      @started_at = args[:started_at] if args[:started_at]
       @method = args[:method] or raise ArgumentError, "must pass :method"
       @headers = (args[:headers] || {}).dup
       if args[:url]
@@ -707,7 +709,6 @@ module RestClient
       else
         response.return!(&block)
       end
-
     end
 
     def parser


### PR DESCRIPTION
Fixes #410, #126

So basically if you add the `args[:count_time] = true` on `RestClient::Request.execute` it will count the time since the start of the execution until the end.

I'm having trouble with 2 tests which don't pass, I normally don't use rspec so if someone can help me out fixing them that would be great. Also I'm not sure if this should have an integration test or a unit test.
