### PR TITLE
Prevent warnings by initializing

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -106,7 +106,7 @@ module RestClient
   # @return [Boolean]
   #
   def self.proxy_set?
-    !!@proxy_set
+    !!(@proxy_set ||= false)
   end
 
   # Setup the log for RestClient calls.


### PR DESCRIPTION
The warning was the following (tested using ruby 2.2.2)

    lib/restclient.rb:109: warning: instance variable @proxy_set not initialized

I run my tests with rspec and warnings on to spot potential issues.