### PR TITLE
redirect when method "GET" or "HEAD"

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -72,7 +72,7 @@ module RestClient
       if (200..207).include? code
         self
       elsif [301, 302, 307].include? code
-        unless [:get, :head].include? args[:method]
+        unless [:get, :head, "GET", "HEAD"].include? args[:method]
           raise exception_with_response
         else
           follow_redirection(&block)


### PR DESCRIPTION
Originally only :get and :head were handled but user can supply method
as a string as well.

Alternatively the HTTP method could be forced into a lowercase Symbol or an uppercase string inside `Request#initialize`. Not sure what would be liked best so submitting this one.

This PR should fix #461