### PR TITLE
normalize HTTP method

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -115,7 +115,12 @@ module RestClient
     end
 
     def initialize args
-      @method = args[:method] or raise ArgumentError, "must pass :method"
+      if args[:method]
+        args[:method] = args[:method].downcase.to_sym
+        @method = args[:method]
+      else
+        raise ArgumentError, "must pass :method"
+      end
       @headers = (args[:headers] || {}).dup
       if args[:url]
         @url = process_url_params(args[:url], headers)


### PR DESCRIPTION
Better fix for issue #461

Earlier I filed pull #462 but I think this one is superior. Leaving both open so you could merge whatever looks better to you. Or you may fix in another way.

Changing `args[:method]` itself into a Symbol is necessary as `args` seem passed to `response` directly.