### PR TITLE
Drop ruby 1.9 support in prep for mime-types upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ os:
   - linux
   - osx
 rvm:
-  - "1.9.3"
   - "2.0.0"
   - "2.1" # latest 2.1.x
   - "2.2" # latest 2.2.x
-  - "jruby-19mode"
+  - "2.3.0" # latest 2.3.x
+  - "jruby-9.0.1.0"
   - "jruby-head"
 script:
   bundle exec rake test
@@ -16,12 +16,14 @@ branches:
     - "readme-edits"
 
 # These versions do not yet work on OS X on Travis
-# (last tested: 2015-09)
+# (last tested: 2016-02)
 matrix:
   exclude:
     - os: osx
-      rvm: 'jruby-19mode'
+      rvm: '2.3.0'
     - os: osx
       rvm: '2.2'
+    - os: osx
+      rvm: 'jruby-9.0.1.0'
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ http://librelist.com/browser/rest.client
 
 ## Requirements
 
-MRI Ruby 1.9.3 and newer are supported. Alternative interpreters compatible with
-1.9+ should work as well.
+MRI Ruby 2.0 and newer are supported. Alternative interpreters compatible with
+2.0+ should work as well.
 
-Earlier Ruby versions such as 1.8.7 and 1.9.2 are no longer supported. These
+Earlier Ruby versions such as 1.8.7, 1.9.2, and 1.9.3 are no longer supported. These
 versions no longer have any official support, and do not receive security
 updates.
 

--- a/history.md
+++ b/history.md
@@ -2,7 +2,7 @@
 
 This release is largely API compatible, but makes several breaking changes.
 
-- Drop support for Ruby 1.9.2
+- Drop support for Ruby 1.9
 - Respect Content-Type charset header provided by server. Previously,
   rest-client would not override the string encoding chosen by Net::HTTP. Now
   responses that specify a charset will yield a body string in that encoding.

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~> 0')
 
   s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
-  s.add_dependency('mime-types', '>= 1.16', '< 3.0')
+  s.add_dependency('mime-types', '>= 1.16', '< 4.0')
   s.add_dependency('netrc', '~> 0.8')
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
Updated #465, for #464, #445, #444, #393.