### PR TITLE
Allow Hash-like objects, not strictly Hashes

### DIFF
--- a/lib/restclient/resource.rb
+++ b/lib/restclient/resource.rb
@@ -39,7 +39,7 @@ module RestClient
     def initialize(url, options={}, backwards_compatibility=nil, &block)
       @url = url
       @block = block
-      if options.class == Hash
+      if options.is_a? Hash
         @options = options
       else # compatibility with previous versions
         @options = { :user => options, :password => backwards_compatibility }


### PR DESCRIPTION
For example, activesupport's `HashWithIndifferentAccess`.