### PR TITLE
Support keep-alive feature by wrap a context outside RestClient::Resquest

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -15,6 +15,7 @@ require File.dirname(__FILE__) + '/restclient/raw_response'
 require File.dirname(__FILE__) + '/restclient/resource'
 require File.dirname(__FILE__) + '/restclient/payload'
 require File.dirname(__FILE__) + '/restclient/windows'
+require File.dirname(__FILE__) + '/restclient/keep_alive_context'
 
 # This module's static methods are the entry point for using the REST client.
 #

--- a/lib/restclient/keep_alive_context.rb
+++ b/lib/restclient/keep_alive_context.rb
@@ -17,18 +17,19 @@ module RestClient
 
        request = Request.new(args.merge(http_object: http_object, keep_alive: true))
        response = request.execute(& block)
-       host_hash[identifier] = request.http_object
+       host_hash[identifier] = request.http_object if request.http_object
        response
      end
 
      def finish
-       host_hash.each do |key, http_object|
+       host_hash.each do |_, http_object|
          http_object.finish if http_object
        end
+       host_hash.clear
      end
 
      def self.start
-       KeepAliveContext context = KeepAliveContext.new
+       context = RestClient::KeepAliveContext.new
        if block_given?
          begin
            return yield(context)

--- a/lib/restclient/keep_alive_context.rb
+++ b/lib/restclient/keep_alive_context.rb
@@ -1,0 +1,44 @@
+module RestClient
+   class KeepAliveContext
+     attr_reader :host_hash
+
+     def initialize
+       @host_hash = {}
+     end
+
+     def execute(args, & block)
+       unless args[:url]
+         raise ArgumentError, "must pass :url"
+       end
+       uri = Utils.parse_url(args[:url])
+
+       identifier = "#{uri.scheme}://#{uri.hostname}:#{uri.port}"
+       http_object = @host_hash[identifier]
+
+       request = Request.new(args.merge(http_object: http_object, keep_alive: true))
+       response = request.execute(& block)
+       @host_hash[identifier] = request.http_object
+       response
+     end
+
+     def finish
+       @host_hash.each do |key, http_object|
+         http_object.finish if http_object
+         puts key
+       end
+     end
+
+     def self.start
+       KeepAliveContext context = KeepAliveContext.new
+       if block_given?
+         begin
+           return yield(context)
+         ensure
+           context.finish
+         end
+       else
+         raise ArgumentError, "must pass block"
+       end
+     end
+   end
+end

--- a/lib/restclient/keep_alive_context.rb
+++ b/lib/restclient/keep_alive_context.rb
@@ -8,23 +8,22 @@ module RestClient
 
      def execute(args, & block)
        unless args[:url]
-         raise ArgumentError, "must pass :url"
+         raise ArgumentError, "must pass url"
        end
        uri = Utils.parse_url(args[:url])
 
        identifier = "#{uri.scheme}://#{uri.hostname}:#{uri.port}"
-       http_object = @host_hash[identifier]
+       http_object = host_hash[identifier]
 
        request = Request.new(args.merge(http_object: http_object, keep_alive: true))
        response = request.execute(& block)
-       @host_hash[identifier] = request.http_object
+       host_hash[identifier] = request.http_object
        response
      end
 
      def finish
-       @host_hash.each do |key, http_object|
+       host_hash.each do |key, http_object|
          http_object.finish if http_object
-         puts key
        end
      end
 

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -649,7 +649,7 @@ module RestClient
         raise error
       end
     ensure
-      @http_object.finish if !@keep_alive and @http_object.started?
+      @http_object.finish if !keep_alive and @http_object.started?
     end
 
     def setup_credentials(req)

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -649,7 +649,7 @@ module RestClient
         raise error
       end
     ensure
-      @http_object.finish unless @keep_alive
+      @http_object.finish if !@keep_alive and @http_object.started?
     end
 
     def setup_credentials(req)

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -41,7 +41,7 @@ module RestClient
     attr_reader :method, :uri, :url, :headers, :cookies, :payload, :proxy,
                 :user, :password, :read_timeout, :max_redirects,
                 :open_timeout, :raw_response, :processed_headers, :args,
-                :ssl_opts
+                :ssl_opts, :keep_alive, :http_object
 
     # An array of previous redirection responses
     attr_accessor :redirection_history
@@ -194,6 +194,9 @@ module RestClient
       @args = args
 
       @before_execution_proc = args[:before_execution_proc]
+
+      @keep_alive = args[:keep_alive]
+      @http_object = args[:http_object]
     end
 
     def execute & block
@@ -344,25 +347,6 @@ module RestClient
       end
     end
 
-    # Parse a string into a URI object. If the string has no HTTP-like scheme
-    # (i.e. scheme followed by '//'), a scheme of 'http' will be added. This
-    # mimics the behavior of browsers and user agents like cURL.
-    #
-    # @param url [String] A URL string.
-    #
-    # @return [URI]
-    #
-    # @raise URI::InvalidURIError on invalid URIs
-    #
-    def parse_url(url)
-      # Prepend http:// unless the string already contains an RFC 3986 scheme
-      # followed by two forward slashes. (The slashes are not part of the URI
-      # RFC, but specified by the URL RFC 1738.)
-      # https://tools.ietf.org/html/rfc3986#section-3.1
-      url = 'http://' + url unless url.match(%r{\A[a-z][a-z0-9+.-]*://}i)
-      URI.parse(url)
-    end
-
     def process_payload(p=nil, parent_key=nil)
       unless p.is_a?(Hash)
         p
@@ -504,7 +488,7 @@ module RestClient
     # @raise URI::InvalidURIError on invalid URIs
     #
     def parse_url_with_auth!(url)
-      uri = parse_url(url)
+      uri = Utils.parse_url(url)
 
       if uri.hostname.nil?
         raise URI::InvalidURIError.new("bad URI(no host provided): #{url}")
@@ -533,12 +517,7 @@ module RestClient
       warned
     end
 
-    def transmit uri, req, payload, & block
-
-      # We set this to true in the net/http block so that we can distinguish
-      # read_timeout from open_timeout. This isn't needed in Ruby >= 2.0.
-      established_connection = false
-
+    def setup_http_object(uri, req)
       setup_credentials req
 
       net = net_http_object(uri.hostname, uri.port)
@@ -594,6 +573,14 @@ module RestClient
         end
         net.open_timeout = @open_timeout
       end
+      net
+    end
+
+    def transmit uri, req, payload, & block
+
+      # We set this to true in the net/http block so that we can distinguish
+      # read_timeout from open_timeout. This isn't needed in Ruby >= 2.0.
+      established_connection = false
 
       RestClient.before_execution_procs.each do |before_proc|
         before_proc.call(req, args)
@@ -605,18 +592,21 @@ module RestClient
 
       log_request
 
-      net.start do |http|
-        established_connection = true
+      unless @http_object
+        @http_object = setup_http_object(uri, req)
+        @http_object.start
+      end
 
-        if @block_response
-          net_http_do_request(http, req, payload, &@block_response)
-        else
-          res = net_http_do_request(http, req, payload) { |http_response|
-            fetch_body(http_response)
-          }
-          log_response res
-          process_result res, & block
-        end
+      established_connection = true
+
+      if @block_response
+        net_http_do_request(@http_object, req, payload, &@block_response)
+      else
+        res = net_http_do_request(@http_object, req, payload) { |http_response|
+          fetch_body(http_response)
+        }
+        log_response res
+        process_result res, & block
       end
     rescue EOFError
       raise RestClient::ServerBrokeConnection
@@ -658,6 +648,8 @@ module RestClient
       else
         raise error
       end
+    ensure
+      @http_object.finish unless @keep_alive
     end
 
     def setup_credentials(req)

--- a/lib/restclient/utils.rb
+++ b/lib/restclient/utils.rb
@@ -89,5 +89,24 @@ module RestClient
 
       [key, pdict]
     end
+
+    # Parse a string into a URI object. If the string has no HTTP-like scheme
+    # (i.e. scheme followed by '//'), a scheme of 'http' will be added. This
+    # mimics the behavior of browsers and user agents like cURL.
+    #
+    # @param url [String] A URL string.
+    #
+    # @return [URI]
+    #
+    # @raise URI::InvalidURIError on invalid URIs
+    #
+    def self.parse_url(url)
+      # Prepend http:// unless the string already contains an RFC 3986 scheme
+      # followed by two forward slashes. (The slashes are not part of the URI
+      # RFC, but specified by the URL RFC 1738.)
+      # https://tools.ietf.org/html/rfc3986#section-3.1
+      url = 'http://' + url unless url.match(%r{\A[a-z][a-z0-9+.-]*://}i)
+      URI.parse(url)
+    end
   end
 end

--- a/spec/integration/request_spec.rb
+++ b/spec/integration/request_spec.rb
@@ -124,4 +124,23 @@ describe RestClient::Request do
     end
   end
 
+  describe "keep alive context" do
+    it "should keep http object in the context " do
+
+      Net::HTTP.any_instance.should_receive(:connect).and_call_original
+
+      context = RestClient::KeepAliveContext.new
+      context.execute(
+          :method => :get,
+          :url => 'https://www.mozilla.org/en-US/'
+      )
+      context.execute(
+          :method => :get,
+          :url => 'https://www.mozilla.org/en-US/'
+      )
+
+      context.host_hash.should have_key 'https://www.mozilla.org:443'
+    end
+  end
+
 end

--- a/spec/unit/keep_alive_context_spec.rb
+++ b/spec/unit/keep_alive_context_spec.rb
@@ -1,0 +1,45 @@
+require_relative './_lib'
+
+describe RestClient::KeepAliveContext, :include_helpers do
+  before do
+    @context = RestClient::KeepAliveContext.new
+
+    @response = double("restclient::response response")
+
+    @http = double("net::http http")
+    Net::HTTP.stub(:new).and_return(@http)
+
+    @host_hash = {}
+
+    @request = double("restclient::request request")
+    RestClient::Request.stub(:new).and_return(@request)
+    @request.stub(:http_object).and_return(@http)
+    @request.stub(:execute).and_return(@response)
+    @request.stub(:host_hash).and_return(@host_hash)
+  end
+
+  it "check args param contains :url" do
+    lambda {
+      @context.execute({})
+    }.should raise_error ArgumentError, /\Amust pass url/
+  end
+
+  it "delegate to execute method of RestClient::Request instance" do
+    @request.should_receive(:execute).and_return(@response)
+    res = @context.execute({url: 'http://some/resource'})
+    res.should eq @response
+  end
+
+  it "save the http object into host_hash member" do
+    @context.host_hash.should_receive(:[]=).with('http://some:80', @http)
+    @context.execute({url: 'http://some/resource'})
+  end
+
+  it "the second request to the same domain will pass the http object to the new request" do
+    @context.execute({url: 'http://some/resource'})
+
+    RestClient::Request.should_receive(:new).with({keep_alive: true, http_object: @http, url: 'http://some/other_resource'})
+    @context.execute({url: 'http://some/other_resource'})
+  end
+
+end

--- a/spec/unit/keep_alive_context_spec.rb
+++ b/spec/unit/keep_alive_context_spec.rb
@@ -42,4 +42,28 @@ describe RestClient::KeepAliveContext, :include_helpers do
     @context.execute({url: 'http://some/other_resource'})
   end
 
+  it "finish should kill all http objects in the context" do
+    @context.execute({url: 'http://some/resource'})
+
+    @http.should_receive :finish
+    @context.host_hash.should_receive :clear
+
+    @context.finish
+  end
+
+  it "start should pass a block" do
+    lambda {
+      RestClient::KeepAliveContext.start
+    }.should raise_error(ArgumentError, /\Amust pass block/)
+  end
+
+  it "start should pass a block" do
+    RestClient::KeepAliveContext.any_instance.should_receive :finish
+
+    ex_context = nil
+    RestClient::KeepAliveContext.start do |context|
+      ex_context = context
+    end
+    ex_context.should be_an_instance_of RestClient::KeepAliveContext
+  end
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -1122,4 +1122,45 @@ describe RestClient::Request, :include_helpers do
         should eq 'https://example.com/path?foo=1&bar=2'
     end
   end
+
+  describe 'keep_alive_context' do
+    it 'should call finish on http object if not in keep_alive mode' do
+      @http.should_receive :request
+      @http.should_receive :finish
+      @request.should_receive(:process_result)
+      @request.should_receive(:log_response)
+      @http.stub(:started?).and_return(true)
+      @request.execute
+    end
+
+    it 'should not call finish on http object if not in keep_alive mode but is not connected' do
+      @http.should_receive :request
+      @http.should_not_receive :finish
+      @request.should_receive(:process_result)
+      @request.should_receive(:log_response)
+      @http.stub(:started?).and_return(false)
+      @request.execute
+    end
+
+    it 'should not call finish on http object if in keep_alive mode' do
+      @http.should_receive :request
+      @http.should_receive :finish
+      @request.should_receive(:process_result)
+      @request.should_receive(:log_response)
+      @http.stub(:started?).and_return(true)
+      @http.stub(:keep_alive).and_return(true)
+      @request.execute
+    end
+
+
+    it 'should not call finish on http object if in keep_alive mode but is not connected' do
+      @http.should_receive :request
+      @http.should_not_receive :finish
+      @request.should_receive(:process_result)
+      @request.should_receive(:log_response)
+      @http.stub(:started?).and_return(false)
+      @http.stub(:keep_alive).and_return(true)
+      @request.execute
+    end
+  end
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -10,11 +10,13 @@ describe RestClient::Request, :include_helpers do
     @uri.stub(:port).and_return(80)
 
     @net = double("net::http base")
-    @http = double("net::http connection")
+    @http = @net # double("net::http connection")
 
     Net::HTTP.stub(:new).and_return(@net)
+    @http.stub(:finish)
+    @http.stub(:started?)
 
-    @net.stub(:start).and_yield(@http)
+    @net.stub(:start) # .and_yield(@http)
     @net.stub(:use_ssl=)
     @net.stub(:verify_mode=)
     @net.stub(:verify_callback=)
@@ -70,46 +72,7 @@ describe RestClient::Request, :include_helpers do
     end
   end
 
-  describe '.parse_url' do
-    it "parses a url into a URI object" do
-      URI.should_receive(:parse).with('http://example.com/resource')
-      @request.parse_url('http://example.com/resource')
-    end
 
-    it "adds http:// to the front of resources specified in the syntax example.com/resource" do
-      URI.should_receive(:parse).with('http://example.com/resource')
-      @request.parse_url('example.com/resource')
-    end
-
-    it 'adds http:// to resources containing a colon' do
-      URI.should_receive(:parse).with('http://example.com:1234')
-      @request.parse_url('example.com:1234')
-    end
-
-    it 'does not add http:// to the front of https resources' do
-      URI.should_receive(:parse).with('https://example.com/resource')
-      @request.parse_url('https://example.com/resource')
-    end
-
-    it 'does not add http:// to the front of capital HTTP resources' do
-      URI.should_receive(:parse).with('HTTP://example.com/resource')
-      @request.parse_url('HTTP://example.com/resource')
-    end
-
-    it 'does not add http:// to the front of capital HTTPS resources' do
-      URI.should_receive(:parse).with('HTTPS://example.com/resource')
-      @request.parse_url('HTTPS://example.com/resource')
-    end
-
-    it 'raises with invalid URI' do
-      lambda {
-        @request.parse_url('http://a@b:c')
-      }.should raise_error(URI::InvalidURIError)
-      lambda {
-        @request.parse_url('http://::')
-      }.should raise_error(URI::InvalidURIError)
-    end
-  end
 
   describe "user - password" do
     it "extracts the username and password when parsing http://user:password@example.com/" do

--- a/spec/unit/utils_spec.rb
+++ b/spec/unit/utils_spec.rb
@@ -68,4 +68,45 @@ describe RestClient::Utils do
         ['form-data', {'name' => 'files', 'filename' => 'fo"o;bar'}]
     end
   end
+
+  describe '.parse_url' do
+    it "parses a url into a URI object" do
+      URI.should_receive(:parse).with('http://example.com/resource')
+      RestClient::Utils.parse_url('http://example.com/resource')
+    end
+
+    it "adds http:// to the front of resources specified in the syntax example.com/resource" do
+      URI.should_receive(:parse).with('http://example.com/resource')
+      RestClient::Utils.parse_url('example.com/resource')
+    end
+
+    it 'adds http:// to resources containing a colon' do
+      URI.should_receive(:parse).with('http://example.com:1234')
+      RestClient::Utils.parse_url('example.com:1234')
+    end
+
+    it 'does not add http:// to the front of https resources' do
+      URI.should_receive(:parse).with('https://example.com/resource')
+      RestClient::Utils.parse_url('https://example.com/resource')
+    end
+
+    it 'does not add http:// to the front of capital HTTP resources' do
+      URI.should_receive(:parse).with('HTTP://example.com/resource')
+      RestClient::Utils.parse_url('HTTP://example.com/resource')
+    end
+
+    it 'does not add http:// to the front of capital HTTPS resources' do
+      URI.should_receive(:parse).with('HTTPS://example.com/resource')
+      RestClient::Utils.parse_url('HTTPS://example.com/resource')
+    end
+
+    it 'raises with invalid URI' do
+      lambda {
+        RestClient::Utils.parse_url('http://a@b:c')
+      }.should raise_error(URI::InvalidURIError)
+      lambda {
+        RestClient::Utils.parse_url('http://::')
+      }.should raise_error(URI::InvalidURIError)
+    end
+  end
 end


### PR DESCRIPTION
The idea is to use the keep_alive feature Net::HTTP object. Currently each restclient request will create a new http object, so I have to manage the alive object outside the restclient request. This way, the old users of RestClient::Request are not affected at all. But if you want to execute multiple requests to the same host while keeping the connection open, you need to create a context. Sample code is like this:

RestClient::KeepAliveContext.start do |context|
    context.get("http://host1/path")
    context.get("https://host2/path")
    context.get("http://host1/otherpath")
end

in this sample, there'll two tcp connections in total, one for host1, the other one for host2.

Please note, this feature doesn't guarantee the connection is kept alive, because the server side may return "connection:close" header to close the connection. However even if this happens, this context will try to get a new connection for the next request, so it'll still work.
