### PR TITLE
Default message for SSLCertificateNotVerified exceptions

### DIFF
--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -236,7 +236,7 @@ module RestClient
   end
 
   class SSLCertificateNotVerified < Exception
-    def initialize(message)
+    def initialize(message = 'SSL certificate not verified')
       super nil, nil
       self.message = message
     end


### PR DESCRIPTION
#### Problem 

While testing (in a Rails app, using MiniTest) that for a collection of exceptions we want handled we get the desired result / behaviour:

```ruby
test '…' do
  HANDLED_EXCEPTIONS.each do |exception|
    RestClient.stubs(:get).raises(exception)

    # assert…
  end
end
```

when adding `RestClient::SSLCertificateNotVerified` to the collection the result is less than expected:

```
RestClient.get(url)
ArgumentError: wrong number of arguments (0 for 1)
from /home/vagrant/src/growth_tools/vendor/bundle/gems/rest-client-1.8.0/lib/restclient/exceptions.rb:191:in `initialize'
```

This appears to be because `SSLCertificateNotVerified` does know of a default message, the way `ServerBrokeConnection` and others do.

#### Solution

Provide a default message when creating a new `SSLCertificateNotVerified` exception.

/review @ab @archiloque @alext please.