### PR TITLE
Prevents a NoMethodError when HTTP server returns a strange response

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -156,7 +156,7 @@ module RestClient
     def _follow_redirection(new_args, &block)
 
       # parse location header and merge into existing URL
-      url = headers[:location]
+      url = headers[:location].to_s
 
       # handle relative redirects
       unless url.start_with?('http')
@@ -175,7 +175,6 @@ module RestClient
       # TODO: figure out what to do with original :cookie, :cookies values
       new_args[:headers]['Cookie'] = HTTP::Cookie.cookie_value(
         cookie_jar.cookies(new_args.fetch(:url)))
-
 
       # prepare new request
       new_req = Request.new(new_args)


### PR DESCRIPTION
Sometimes, web servers do things that are just completely wrong. We
don't want this to break RestClient in a way we feel unsafe rescuing
from.

This small tweak allows us to raise a more appropriate error, stil
strange, but at least one we can rescue from safely when web servers
are out of their damn mind.

Previously, this request would throw `NoMethodError`, with this fix it
will now throw `RestClient::Found`. Still strange, but allows other
tools to use without forcing a rescue on a useful exception.

Example of strange response from web server:
```
nhance:rest-client/ (master✗) $ curl -v -v
http://www.citysoulsurge.com/javascripts/controls.js
[10:20:28]
*   Trying 184.173.106.59...
* Connected to www.citysoulsurge.com (184.173.106.59) port 80 (#0)
> GET /javascripts/controls.js HTTP/1.1
> Host: www.citysoulsurge.com
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 302 Not Found
< Content-Type: text/html
< X-Cacheable: YES
< Content-Length: 0
< Accept-Ranges: bytes
< Date: Thu, 14 Apr 2016 14:20:32 GMT
< Connection: keep-alive
< age: 0
<
* Connection #0 to host www.citysoulsurge.com left intact
```