### PR TITLE
Drop Ruby 1.9 support, fix Travis test versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Available ruby versions: http://rubies.travis-ci.org/
+
 language: ruby
 os:
   - linux
@@ -6,8 +8,9 @@ rvm:
   - "2.0.0"
   - "2.1" # latest 2.1.x
   - "2.2" # latest 2.2.x
-  - "2.3.0" # latest 2.3.x
-  - "jruby-9.0.1.0"
+  - "2.3.1" # TODO: switch to "2.3" once travis fixes it
+  - "ruby-head"
+  - "jruby-9.0.5.0"
   - "jruby-head"
 script:
   bundle exec rake test
@@ -15,15 +18,25 @@ branches:
   except:
     - "readme-edits"
 
-# These versions do not yet work on OS X on Travis
-# (last tested: 2016-02)
+# Travis OS X support is pretty janky. These are some hacks to include tests
+# only on versions that actually work.
+# (last tested: 2016-04)
 matrix:
   exclude:
     - os: osx
-      rvm: '2.3.0'
-    - os: osx
       rvm: '2.2'
     - os: osx
-      rvm: 'jruby-9.0.1.0'
+      rvm: '2.3.1' # No 2.3.x at all
+  include:
+    - os: osx
+      rvm: '2.2.2' # Travis OS X doesn't have 2.2 aliases
+  allow_failures:
+    - rvm: 'ruby-head'
+    - os: osx
+      rvm: 'jruby-9.0.5.0'
+    - os: osx
+      rvm: 'jruby-head'
+    - os: linux
+      rvm: 'jruby-head'
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ os:
   - linux
   - osx
 rvm:
-  - "1.9.3"
   - "2.0.0"
   - "2.1" # latest 2.1.x
   - "2.2" # latest 2.2.x
-  - "jruby-19mode"
+  - "2.3.0" # latest 2.3.x
+  - "jruby-9.0.1.0"
   - "jruby-head"
 script:
   bundle exec rake test
@@ -16,12 +16,14 @@ branches:
     - "readme-edits"
 
 # These versions do not yet work on OS X on Travis
-# (last tested: 2015-09)
+# (last tested: 2016-02)
 matrix:
   exclude:
     - os: osx
-      rvm: 'jruby-19mode'
+      rvm: '2.3.0'
     - os: osx
       rvm: '2.2'
+    - os: osx
+      rvm: 'jruby-9.0.1.0'
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ http://librelist.com/browser/rest.client
 
 ## Requirements
 
-MRI Ruby 1.9.3 and newer are supported. Alternative interpreters compatible with
-1.9+ should work as well.
+MRI Ruby 2.0 and newer are supported. Alternative interpreters compatible with
+2.0+ should work as well.
 
-Earlier Ruby versions such as 1.8.7 and 1.9.2 are no longer supported. These
+Earlier Ruby versions such as 1.8.7, 1.9.2, and 1.9.3 are no longer supported. These
 versions no longer have any official support, and do not receive security
 updates.
 

--- a/history.md
+++ b/history.md
@@ -3,6 +3,7 @@
 This release is largely API compatible, but makes several breaking changes.
 
 - Drop support for Ruby 1.9
+- Allow mime-types as new as 3.x (requires ruby 2.0)
 - Respect Content-Type charset header provided by server. Previously,
   rest-client would not override the string encoding chosen by Net::HTTP. Now
   responses that specify a charset will yield a body string in that encoding.

--- a/history.md
+++ b/history.md
@@ -2,7 +2,7 @@
 
 This release is largely API compatible, but makes several breaking changes.
 
-- Drop support for Ruby 1.9.2
+- Drop support for Ruby 1.9
 - Respect Content-Type charset header provided by server. Previously,
   rest-client would not override the string encoding chosen by Net::HTTP. Now
   responses that specify a charset will yield a body string in that encoding.

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -199,8 +199,7 @@ module RestClient
     def execute & block
       # With 2.0.0+, net/http accepts URI objects in requests and handles wrapping
       # IPv6 addresses in [] for use in the Host request header.
-      request_uri = RUBY_VERSION >= "2.0.0" ? uri : uri.request_uri
-      transmit uri, net_http_request_class(method).new(request_uri, processed_headers), payload, & block
+      transmit uri, net_http_request_class(method).new(uri, processed_headers), payload, & block
     ensure
       payload.close if payload
     end

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~> 0')
 
   s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
-  s.add_dependency('mime-types', '>= 1.16', '< 3.0')
+  s.add_dependency('mime-types', '>= 1.16', '< 4.0')
   s.add_dependency('netrc', '~> 0.8')
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
This builds upon the work of #466.