### PR TITLE
Fix cookie_jar for URL passed without scheme.

### DIFF
--- a/history.md
+++ b/history.md
@@ -79,6 +79,8 @@ This release is largely API compatible, but makes several breaking changes.
 - Add a few more exception classes for obscure HTTP status codes.
 - Multipart: use a much more robust multipart boundary with greater entropy.
 - Make `RestClient::Payload::Base#inspect` stop pretending to be a String.
+- Add `Request#redacted_uri` and `Request#redacted_url` to display the URI
+  with any password redacted.
 
 # 2.0.0.rc1
 

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -59,7 +59,7 @@ module RestClient
 
       jar = HTTP::CookieJar.new
       headers.fetch(:set_cookie, []).each do |cookie|
-        jar.parse(cookie, @request.url)
+        jar.parse(cookie, @request.uri)
       end
 
       @cookie_jar = jar

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -426,20 +426,26 @@ module RestClient
       end
     end
 
+    def redacted_uri
+      if uri.password
+        sanitized_uri = uri.dup
+        sanitized_uri.password = 'REDACTED'
+        sanitized_uri
+      else
+        uri
+      end
+    end
+
+    def redacted_url
+      redacted_uri.to_s
+    end
+
     def log_request
       return unless RestClient.log
 
-      if uri.password
-        sanitized_uri = uri.dup
-        sanitized_uri.password = "REDACTED"
-        sanitized_url = sanitized_uri.to_s
-      else
-        sanitized_url = uri.to_s
-      end
-
       out = []
 
-      out << "RestClient.#{method} #{sanitized_url.inspect}"
+      out << "RestClient.#{method} #{redacted_url.inspect}"
       out << payload.short_inspect if payload
       out << processed_headers.to_a.sort.map { |(k, v)| [k.inspect, v.inspect].join("=>") }.join(", ")
       RestClient.log << out.join(', ') + "\n"

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module Helpers
   def response_double(opts={})
     double('response', {:to_hash => {}}.merge(opts))
@@ -13,7 +15,8 @@ module Helpers
   end
 
   def request_double(url: 'http://example.com', method: 'get')
-    double('request', url: url, method: method, user: nil, password: nil,
+    double('request', url: url, uri: URI.parse(url), method: method,
+           user: nil, password: nil,
            redirection_history: nil, args: {url: url, method: method})
   end
 end

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -17,7 +17,7 @@ describe RestClient::AbstractResponse, :include_helpers do
 
   before do
     @net_http_res = double('net http response')
-    @request = double('restclient request', url: 'http://example.com', method: 'get')
+    @request = request_double(url: 'http://example.com', method: 'get')
     @response = MyAbstractResponse.new(@net_http_res, @request)
   end
 

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -77,6 +77,33 @@ describe RestClient::AbstractResponse, :include_helpers do
     @response.cookies.should eq({ 'session_id' => 'BAh7BzoNYXBwX25hbWUiEGFwcGxpY2F0aW9uOgpsb2dpbiIKYWRtaW4%3D%0A--08114ba654f17c04d20dcc5228ec672508f738ca' })
   end
 
+  describe '.cookie_jar' do
+    it 'extracts cookies into cookie jar' do
+      @net_http_res.should_receive(:to_hash).and_return('set-cookie' => ['session_id=1; path=/'])
+      @response.cookie_jar.should be_a HTTP::CookieJar
+
+      cookie = @response.cookie_jar.cookies.first
+      cookie.domain.should eq 'example.com'
+      cookie.name.should eq 'session_id'
+      cookie.value.should eq '1'
+      cookie.path.should eq '/'
+    end
+
+    it 'handles cookies when URI scheme is implicit' do
+      net_http_res = double('net http response')
+      net_http_res.should_receive(:to_hash).and_return('set-cookie' => ['session_id=1; path=/'])
+      request = double(url: 'example.com', uri: URI.parse('http://example.com'), method: 'get')
+      response = MyAbstractResponse.new(net_http_res, request)
+      response.cookie_jar.should be_a HTTP::CookieJar
+
+      cookie = response.cookie_jar.cookies.first
+      cookie.domain.should eq 'example.com'
+      cookie.name.should eq 'session_id'
+      cookie.value.should eq '1'
+      cookie.path.should eq '/'
+    end
+  end
+
   it "can access the net http result directly" do
     @response.net_http_res.should eq @net_http_res
   end
@@ -106,9 +133,9 @@ describe RestClient::AbstractResponse, :include_helpers do
     end
 
     it "should gracefully handle 302 redirect with no location header" do
-    @net_http_res = response_double(code: 302, location: nil)
-    @request = request_double()
-    @response = MyAbstractResponse.new(@net_http_res, @request)
+      @net_http_res = response_double(code: 302, location: nil)
+      @request = request_double()
+      @response = MyAbstractResponse.new(@net_http_res, @request)
       lambda { @response.return! }.should raise_error RestClient::Found
     end
   end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -70,43 +70,33 @@ describe RestClient::Request, :include_helpers do
     end
   end
 
-  describe '.parse_url' do
-    it "parses a url into a URI object" do
-      URI.should_receive(:parse).with('http://example.com/resource')
-      @request.parse_url('http://example.com/resource')
-    end
-
+  describe '.normalize_url' do
     it "adds http:// to the front of resources specified in the syntax example.com/resource" do
-      URI.should_receive(:parse).with('http://example.com/resource')
-      @request.parse_url('example.com/resource')
+      @request.normalize_url('example.com/resource').should eq 'http://example.com/resource'
     end
 
     it 'adds http:// to resources containing a colon' do
-      URI.should_receive(:parse).with('http://example.com:1234')
-      @request.parse_url('example.com:1234')
+      @request.normalize_url('example.com:1234').should eq 'http://example.com:1234'
     end
 
     it 'does not add http:// to the front of https resources' do
-      URI.should_receive(:parse).with('https://example.com/resource')
-      @request.parse_url('https://example.com/resource')
+      @request.normalize_url('https://example.com/resource').should eq 'https://example.com/resource'
     end
 
     it 'does not add http:// to the front of capital HTTP resources' do
-      URI.should_receive(:parse).with('HTTP://example.com/resource')
-      @request.parse_url('HTTP://example.com/resource')
+      @request.normalize_url('HTTP://example.com/resource').should eq 'HTTP://example.com/resource'
     end
 
     it 'does not add http:// to the front of capital HTTPS resources' do
-      URI.should_receive(:parse).with('HTTPS://example.com/resource')
-      @request.parse_url('HTTPS://example.com/resource')
+      @request.normalize_url('HTTPS://example.com/resource').should eq 'HTTPS://example.com/resource'
     end
 
     it 'raises with invalid URI' do
       lambda {
-        @request.parse_url('http://a@b:c')
+        RestClient::Request.new(method: :get, url: 'http://a@b:c')
       }.should raise_error(URI::InvalidURIError)
       lambda {
-        @request.parse_url('http://::')
+        RestClient::Request.new(method: :get, url: 'http://::')
       }.should raise_error(URI::InvalidURIError)
     end
   end


### PR DESCRIPTION
Normalize the URL earlier in processing and save it so that @url will
always have a protocol. Also pass @uri for cookie_jar initialization to
avoid extra unnecessary URI parsing step.

Fixes: #487