### PR TITLE
Update to webmock 2.0

### DIFF
--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/rest-client/rest-client'
   s.summary = 'Simple HTTP and REST client for Ruby, inspired by microframework syntax for specifying actions.'
 
-  s.add_development_dependency('webmock', '~> 1.4')
+  s.add_development_dependency('webmock', '~> 2.0')
   s.add_development_dependency('rspec', '~> 2.99')
   s.add_development_dependency('pry', '~> 0')
   s.add_development_dependency('pry-doc', '~> 0')

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -109,8 +109,8 @@ describe RestClient::Response, :include_helpers do
     end
 
     it "follows a redirection and keep the parameters" do
-      stub_request(:get, 'http://foo:bar@some/resource').with(:headers => {'Accept' => 'application/json'}).to_return(:body => '', :status => 301, :headers => {'Location' => 'http://new/resource'})
-      stub_request(:get, 'http://foo:bar@new/resource').with(:headers => {'Accept' => 'application/json'}).to_return(:body => 'Foo')
+      stub_request(:get, 'http://some/resource').with(:headers => {'Accept' => 'application/json'}, :basic_auth => ['foo', 'bar']).to_return(:body => '', :status => 301, :headers => {'Location' => 'http://new/resource'})
+      stub_request(:get, 'http://new/resource').with(:headers => {'Accept' => 'application/json'}, :basic_auth => ['foo', 'bar']).to_return(:body => 'Foo')
       RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :user => 'foo', :password => 'bar', :headers => {:accept => :json}).body.should eq 'Foo'
     end
 


### PR DESCRIPTION
I updated development dependency  webmock to version 2.0, because I wanted to use it.

I changed stub_request basic authentication logic, because the unit test got an error, and below reason.
https://github.com/bblimke/webmock
> Important! Since version 2.0.0, WebMock does not match credentials provided in Authorization header and credentials provided in the userinfo of a url. I.e. stub_request(:get, "user:pass@www.example.com") does not match a request with credentials provided in the Athoriation header.

Just changed from "foo:bar@www.example.com" to "www.example.com" and :basic_auth => ['foo', 'bar'].

Could you merge this modification?

Thanks.
