### PR TITLE
Use cookie jars consistently for requests, responses, and redirection.

### DIFF
--- a/history.md
+++ b/history.md
@@ -47,6 +47,14 @@ This release is largely API compatible, but makes several breaking changes.
 - Handle multiple HTTP response headers with the same name (except for
   Set-Cookie, which is special) by joining the values with a comma space,
   compliant with RFC 7230
+- Rewrite cookie support to be much smarter and to use cookie jars consistently
+  - The `:cookies` option may now be a Hash of Strings, an Array of
+    HTTP::Cookie objects, or a full HTTP::CookieJar.
+  - Add `RestClient::Request#cookie_jar` and reimplement `Request#cookies` to
+    be a wrapper around the cookie jar.
+  - Still support passing the `:cookies` option in the headers hash, but now
+    raise ArgumentError if that option is also passed to `Request#initialize`.
+  - Warn if both `:cookies` and a `Cookie` header are supplied.
 - Don't set basic auth header if explicit `Authorization` header is specified
 - Add `:proxy` option to requests, which can be used for thread-safe
   per-request proxy configuration, overriding `RestClient.proxy`

--- a/history.md
+++ b/history.md
@@ -48,6 +48,8 @@ This release is largely API compatible, but makes several breaking changes.
   Set-Cookie, which is special) by joining the values with a comma space,
   compliant with RFC 7230
 - Rewrite cookie support to be much smarter and to use cookie jars consistently
+  for requests, responses, and redirection (resolving long-standing complaints
+  about the previously broken behavior):
   - The `:cookies` option may now be a Hash of Strings, an Array of
     HTTP::Cookie objects, or a full HTTP::CookieJar.
   - Add `RestClient::Request#cookie_jar` and reimplement `Request#cookies` to
@@ -55,6 +57,11 @@ This release is largely API compatible, but makes several breaking changes.
   - Still support passing the `:cookies` option in the headers hash, but now
     raise ArgumentError if that option is also passed to `Request#initialize`.
   - Warn if both `:cookies` and a `Cookie` header are supplied.
+  - Use the `Request#cookie_jar` as the basis for `Response#cookie_jar`,
+    creating a copy of the jar and adding any newly received cookies.
+  - When following redirection, also use this same strategy so that cookies
+    from the original request are carried through in a standards-compliant way
+    by the cookie jar.
 - Don't set basic auth header if explicit `Authorization` header is specified
 - Add `:proxy` option to requests, which can be used for thread-safe
   per-request proxy configuration, overriding `RestClient.proxy`

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -82,11 +82,13 @@ module RestClient
       when 301, 302, 307
         case request.method
         when 'get', 'head'
+          check_max_redirects
           follow_redirection(&block)
         else
           raise exception_with_response
         end
       when 303
+        check_max_redirects
         follow_get_redirection(&block)
       else
         raise exception_with_response
@@ -178,9 +180,6 @@ module RestClient
       end
       new_args[:url] = url
 
-      if request.max_redirects <= 0
-        raise exception_with_response
-      end
       new_args[:password] = request.password
       new_args[:user] = request.user
       new_args[:headers] = request.headers
@@ -199,6 +198,12 @@ module RestClient
 
       # execute redirected request
       new_req.execute(&block)
+    end
+
+    def check_max_redirects
+      if request.max_redirects <= 0
+        raise exception_with_response
+      end
     end
 
     def exception_with_response

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -39,11 +39,20 @@ module RestClient
       history
     end
 
-    # Hash of cookies extracted from response headers
+    # Hash of cookies extracted from response headers.
+    #
+    # NB: This will return only cookies whose domain matches this request, and
+    # may not even return all of those cookies if there are duplicate names.
+    # Use the full cookie_jar for more nuanced access.
+    #
+    # @see #cookie_jar
+    #
+    # @return [Hash]
+    #
     def cookies
       hash = {}
 
-      cookie_jar.cookies.each do |cookie|
+      cookie_jar.cookies(@request.uri).each do |cookie|
         hash[cookie.name] = cookie.value
       end
 
@@ -57,7 +66,7 @@ module RestClient
     def cookie_jar
       return @cookie_jar if @cookie_jar
 
-      jar = HTTP::CookieJar.new
+      jar = @request.cookie_jar.dup
       headers.fetch(:set_cookie, []).each do |cookie|
         jar.parse(cookie, @request.uri)
       end
@@ -185,10 +194,8 @@ module RestClient
       new_args[:headers] = request.headers
       new_args[:max_redirects] = request.max_redirects - 1
 
-      # TODO: figure out what to do with original :cookie, :cookies values
-      new_args[:headers]['Cookie'] = HTTP::Cookie.cookie_value(
-        cookie_jar.cookies(new_args.fetch(:url)))
-
+      # pass through our new cookie jar
+      new_args[:cookies] = cookie_jar
 
       # prepare new request
       new_req = Request.new(new_args)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -16,7 +16,7 @@ module Helpers
 
   def request_double(url: 'http://example.com', method: 'get')
     double('request', url: url, uri: URI.parse(url), method: method,
-           user: nil, password: nil,
+           user: nil, password: nil, cookie_jar: HTTP::CookieJar.new,
            redirection_history: nil, args: {url: url, method: method})
   end
 end

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -128,6 +128,7 @@ describe RestClient::AbstractResponse, :include_helpers do
 
     it "should follow 302 redirect" do
       @net_http_res.should_receive(:code).and_return('302')
+      @response.should_receive(:check_max_redirects).and_return('fake-check')
       @response.should_receive(:follow_redirection).and_return('fake-redirection')
       @response.return!.should eq 'fake-redirection'
     end
@@ -136,6 +137,7 @@ describe RestClient::AbstractResponse, :include_helpers do
       @net_http_res = response_double(code: 302, location: nil)
       @request = request_double()
       @response = MyAbstractResponse.new(@net_http_res, @request)
+      @response.should_receive(:check_max_redirects).and_return('fake-check')
       lambda { @response.return! }.should raise_error RestClient::Found
     end
   end

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -92,7 +92,8 @@ describe RestClient::AbstractResponse, :include_helpers do
     it 'handles cookies when URI scheme is implicit' do
       net_http_res = double('net http response')
       net_http_res.should_receive(:to_hash).and_return('set-cookie' => ['session_id=1; path=/'])
-      request = double(url: 'example.com', uri: URI.parse('http://example.com'), method: 'get')
+      request = double(url: 'example.com', uri: URI.parse('http://example.com'),
+                       method: 'get', cookie_jar: HTTP::CookieJar.new)
       response = MyAbstractResponse.new(net_http_res, request)
       response.cookie_jar.should be_a HTTP::CookieJar
 

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -216,6 +216,22 @@ describe RestClient::Response, :include_helpers do
       }
       WebMock.should have_requested(:get, 'http://some/redirect-2').times(5)
     end
+
+    it "allows for manual following of redirects" do
+      stub_request(:get, 'http://some/redirect-1').to_return(:body => '', :status => 301, :headers => {'Location' => 'http://some/resource'})
+      stub_request(:get, 'http://some/resource').to_return(:body => 'Qux', :status => 200)
+
+      begin
+        RestClient::Request.execute(url: 'http://some/redirect-1', method: :get, max_redirects: 0)
+      rescue RestClient::MovedPermanently => err
+        resp = err.response.follow_redirection
+      else
+        raise 'notreached'
+      end
+
+      resp.code.should eq 200
+      resp.body.should eq 'Qux'
+    end
   end
 
 end


### PR DESCRIPTION
Implement cookie jar support for :cookies in Requests. The `:cookies` option may now be:
- A hash of strings
- An array of HTTP::Cookie objects
- A full HTTP::CookieJar

Rewrite all of the cookie processing on RestClient::Request to operate in
terms of HTTP::CookieJar, and expose `Request#cookie_jar` and
`Request#make_cookie_header` methods.

Prefer :cookies over the "Cookie" HTTP header, but warn when overriding.

Use this new request cookie jar as the basis for response cookie jars and for
redirection, which means that we will carry through cookies in a browser like
way. This makes the behavior much more sane and self-consistent.