### PR TITLE
updating readme with timeouts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,24 @@ RestClient.post 'http://example.com/resource', {:foo => 'bar', :baz => 'qux'}, {
 RestClient.delete 'http://example.com/resource', {:Authorization => 'Bearer cT0febFoD5lxAlNAXHo6g'}
 ```
 
+## Timeouts
+
+By default the timeout for a request is 60 seconds. Timeouts for your request can
+be adjusted by setting the `timeout:` to the number of seconds that you would like
+the request to wait. Setting `timeout:` will override both `read_timeout:` and `open_timeout:`.
+
+```ruby
+RestClient::Request.execute(method: :get, url: 'http://example.com/resource',
+                            timeout: 120)
+```
+
+Additionally, you can set `read_timeout:` and `open_timeout:` separately.
+
+```ruby
+RestClient::Request.execute(method: :get, url: 'http://example.com/resource',
+                            read_timeout: 120, open_timeout: 240)
+```
+
 ## Cookies
 
 Request and Response objects know about HTTP cookies, and will automatically


### PR DESCRIPTION
It was quite difficult for me to diagnose a gateway error that I was having on a services oriented architecture.  The root of the problem was a slightly long running request where I needed to bump the timeout of rest-client up a bit.  Finding documentation on this was a little on the difficult side, and only one stack overflow writeup had a rich answer.  I figured this should go into the readme in case others run into the same issue.