### PR TITLE
Auth in URI no longer overwritten by nil args

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -132,8 +132,8 @@ module RestClient
       @cookie_jar = process_cookie_args!(@uri, @headers, args)
 
       @payload = Payload.generate(args[:payload])
-      @user = args[:user]
-      @password = args[:password]
+      @user = args[:user] if args[:user]
+      @password = args[:password]  if args[:password]
       if args.include?(:timeout)
         @read_timeout = args[:timeout]
         @open_timeout = args[:timeout]

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -12,6 +12,14 @@ describe RestClient do
     expect(response.body).to eq body
   end
 
+  it "a request with basic authorization in the url" do
+    body = 'abc'
+    stub_request(:get, "www.example.com").with(:headers => {'Authorization' => "Basic #{Base64.strict_encode64("testuser:testpass")}"}).to_return(:body => body, :status => 200)
+    response = RestClient.get "http://testuser:testpass@www.example.com"
+    expect(response.code).to eq 200
+    expect(response.body).to eq body
+  end
+
   it "a simple request with gzipped content" do
     stub_request(:get, "www.example.com").with(:headers => { 'Accept-Encoding' => 'gzip, deflate' }).to_return(:body => "\037\213\b\b\006'\252H\000\003t\000\313T\317UH\257\312,HM\341\002\000G\242(\r\v\000\000\000", :status => 200,  :headers => { 'Content-Encoding' => 'gzip' } )
     response = RestClient.get "www.example.com"


### PR DESCRIPTION
No auth was being passed that is in the URI, as it was being overwritten by `auth[:user]` which is nil, unless passed in too.