### PR TITLE
Fix handling of basic auth user/password.

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -132,8 +132,10 @@ module RestClient
       @cookie_jar = process_cookie_args!(@uri, @headers, args)
 
       @payload = Payload.generate(args[:payload])
-      @user = args[:user]
-      @password = args[:password]
+
+      @user = args[:user] if args.include?(:user)
+      @password = args[:password] if args.include?(:password)
+
       if args.include?(:timeout)
         @read_timeout = args[:timeout]
         @open_timeout = args[:timeout]

--- a/spec/integration/httpbin_spec.rb
+++ b/spec/integration/httpbin_spec.rb
@@ -68,5 +68,19 @@ describe RestClient::Request do
         expect(ex.response.cookies['foo']).to eq '"bar:baz"'
       }
     end
+
+    it 'sends basic auth' do
+      user = 'user'
+      pass = 'pass'
+
+      data = execute_httpbin_json("basic-auth/#{user}/#{pass}", method: :get, user: user, password: pass)
+      expect(data).to eq({'authenticated' => true, 'user' => user})
+
+      expect {
+        execute_httpbin_json("basic-auth/#{user}/#{pass}", method: :get, user: user, password: 'badpass')
+      }.to raise_error(RestClient::Unauthorized) { |ex|
+        expect(ex.http_code).to eq 401
+      }
+    end
   end
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -103,25 +103,33 @@ describe RestClient::Request, :include_helpers do
 
   describe "user - password" do
     it "extracts the username and password when parsing http://user:password@example.com/" do
-      allow(URI).to receive(:parse).and_return(double('uri', user: 'joe', password: 'pass1', hostname: 'example.com'))
       @request.send(:parse_url_with_auth!, 'http://joe:pass1@example.com/resource')
       expect(@request.user).to eq 'joe'
       expect(@request.password).to eq 'pass1'
     end
 
     it "extracts with escaping the username and password when parsing http://user:password@example.com/" do
-      allow(URI).to receive(:parse).and_return(double('uri', user: 'joe%20', password: 'pass1', hostname: 'example.com'))
       @request.send(:parse_url_with_auth!, 'http://joe%20:pass1@example.com/resource')
       expect(@request.user).to eq 'joe '
       expect(@request.password).to eq 'pass1'
     end
 
     it "doesn't overwrite user and password (which may have already been set by the Resource constructor) if there is no user/password in the url" do
-      allow(URI).to receive(:parse).and_return(double('uri', user: nil, password: nil, hostname: 'example.com'))
-      @request = RestClient::Request.new(:method => 'get', :url => 'example.com', :user => 'beth', :password => 'pass2')
-      @request.send(:parse_url_with_auth!, 'http://example.com/resource')
-      expect(@request.user).to eq 'beth'
-      expect(@request.password).to eq 'pass2'
+      request = RestClient::Request.new(method: :get, url: 'http://example.com/resource', user: 'beth', password: 'pass2')
+      expect(request.user).to eq 'beth'
+      expect(request.password).to eq 'pass2'
+    end
+
+    it 'uses the username and password from the URL' do
+      request = RestClient::Request.new(method: :get, url: 'http://person:secret@example.com/resource')
+      expect(request.user).to eq 'person'
+      expect(request.password).to eq 'secret'
+    end
+
+    it 'overrides URL user/pass with explicit options' do
+      request = RestClient::Request.new(method: :get, url: 'http://person:secret@example.com/resource', user: 'beth', password: 'pass2')
+      expect(request.user).to eq 'beth'
+      expect(request.password).to eq 'pass2'
     end
   end
 

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -253,19 +253,17 @@ describe RestClient::Request, :include_helpers do
   end
 
   it "uses netrc credentials" do
-    allow(URI).to receive(:parse).and_return(double('uri', :user => nil, :password => nil, :hostname => 'example.com'))
-    allow(Netrc).to receive(:read).and_return('example.com' => ['a', 'b'])
-    @request.send(:parse_url_with_auth!, 'http://example.com/resource')
-    expect(@request.user).to eq 'a'
-    expect(@request.password).to eq 'b'
+    expect(Netrc).to receive(:read).and_return('example.com' => ['a', 'b'])
+    request = RestClient::Request.new(:method => :put, :url => 'http://example.com/', :payload => 'payload')
+    expect(request.user).to eq 'a'
+    expect(request.password).to eq 'b'
   end
 
   it "uses credentials in the url in preference to netrc" do
-    allow(URI).to receive(:parse).and_return(double('uri', :user => 'joe%20', :password => 'pass1', :hostname => 'example.com'))
     allow(Netrc).to receive(:read).and_return('example.com' => ['a', 'b'])
-    @request.send(:parse_url_with_auth!, 'http://joe%20:pass1@example.com/resource')
-    expect(@request.user).to eq 'joe '
-    expect(@request.password).to eq 'pass1'
+    request = RestClient::Request.new(:method => :put, :url =>  'http://joe%20:pass1@example.com/', :payload => 'payload')
+    expect(request.user).to eq 'joe '
+    expect(request.password).to eq 'pass1'
   end
 
   it "determines the Net::HTTP class to instantiate by the method name" do


### PR DESCRIPTION
Handling of user/password parameters was broken by
76f7593bb13ae20de43b78c5c1adfc5bda297d2d. This change made it impossible to
pass user/password via a URL or netrc. This additionally revealed that the
relevant tests were not actually testing the code.

Fix all of these with some minimal changes.