### PR TITLE
Allow passing ParamsArray as a payload

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -17,6 +17,12 @@ module RestClient
         else
           UrlEncoded.new(params)
         end
+      elsif params.is_a?(ParamsArray)
+        if _has_file?(params)
+          Multipart.new(params)
+        else
+          UrlEncoded.new(params)
+        end
       elsif params.respond_to?(:read)
         Streamed.new(params)
       else

--- a/spec/unit/payload_spec.rb
+++ b/spec/unit/payload_spec.rb
@@ -259,5 +259,11 @@ Content-Type: text/plain\r
     it "shouldn't treat hashes as streameable" do
       expect(RestClient::Payload.generate({"foo" => 'bar'})).to be_kind_of(RestClient::Payload::UrlEncoded)
     end
+
+    it "should recognize multipart payload wrapped in ParamsArray" do
+      f = File.new(File.dirname(__FILE__) + "/master_shake.jpg")
+      params = RestClient::ParamsArray.new([[:image, f]])
+      expect(RestClient::Payload.generate(params)).to be_kind_of(RestClient::Payload::Multipart)
+    end
   end
 end


### PR DESCRIPTION
Thanks for the handy `ParamsArray` class. 

Couldn't make it work properly when passed as a payload, seems to be a bug.
