### PR TITLE
README - Update usage of return!

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ RestClient.get('http://my-rest-service.com/resource'){ |response, request, resul
   when 423
     raise SomeCustomExceptionIfYouWant
   else
-    response.return!(request, result, &block)
+    response.return!(&block)
   end
 }
 
@@ -328,7 +328,7 @@ RestClient.get('http://my-rest-service.com/resource'){ |response, request, resul
   if [301, 302, 307].include? response.code
     response.follow_redirection(request, result, &block)
   else
-    response.return!(request, result, &block)
+    response.return!(&block)
   end
 }
 ```


### PR DESCRIPTION
`return!` does not receive the request and response parameters, only the block: https://github.com/rest-client/rest-client/blob/master/lib/restclient/abstract_response.rb#L87
