### PR TITLE
Only do (expensive) SSL context setups when actually accessing HTTPS URLs

### DIFF
--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe RestClient::Request do
   before do
-    @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload')
+    @request = RestClient::Request.new(:method => :put, :url => 'https://some/resource', :payload => 'payload')
 
     @uri = double("uri")
     @uri.stub(:request_uri).and_return('/resource')
@@ -230,7 +230,7 @@ describe RestClient::Request do
   end
 
   it "executes by constructing the Net::HTTP object, headers, and payload and calling transmit" do
-    @request.should_receive(:parse_url_with_auth).with('http://some/resource').and_return(@uri)
+    @request.should_receive(:parse_url_with_auth).with('https://some/resource').and_return(@uri)
     klass = double("net:http class")
     @request.should_receive(:net_http_request_class).with(:put).and_return(klass)
     klass.should_receive(:new).and_return('result')
@@ -519,7 +519,7 @@ describe RestClient::Request do
     end
 
     it "should set net.verify_mode to OpenSSL::SSL::VERIFY_NONE if verify_ssl is false" do
-      @request = RestClient::Request.new(:method => :put, :verify_ssl => false, :url => 'http://some/resource', :payload => 'payload')
+      @request = RestClient::Request.new(:method => :put, :verify_ssl => false, :url => 'https://some/resource', :payload => 'payload')
       @net.should_receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
       @http.stub(:request)
       @request.stub(:process_result)


### PR DESCRIPTION
NOTE: GitHub mangles whitespace-only changes pretty badly in this case _sigh_

While upgrading our stack from CentOS 6.x to CentOS 7.x we noticed that between
rest-client 1.6.8 and 1.8.0 SSL certificate verification was added (yay! \o/),
which comes at some expense of SSL CA path setups and the like.

This expense cost us dearly, as we were doing a lot of backend requests via
CouchRest, which itself uses rest-client. For performance reasons, backend
communication is done unencrypted inside our secured network, so the SSL setup
was unnecessary. Our application code still needs to be ported to newer
versions of CouchRest and rest-client, so a patch for the 1.8.x branch was
needed.

This patch ensures SSL context setup is only done when accessing https URLs,
and updates related tests. Introduction of security issues by this PR is very
unlikely.

Forward-porting of this patch is recommended, additional recommended changes
might be caching/pooling of request objects or pre-creation/sharing of SSL CA
path information. The possible security implications of this additional change
where not explored in the scope of the current PR.
