### PR TITLE
Travis: fix up bundler and add commentary around failing versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ script:
 branches:
   except:
     - "readme-edits"
+before_install:
+  # bundler installation needed for jruby-head
+  # https://github.com/travis-ci/travis-ci/issues/5861
+  - gem install bundler
 
 # Travis OS X support is pretty janky. These are some hacks to include tests
 # only on versions that actually work.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
 rvm:
   - "2.0.0"
   - "2.1" # latest 2.1.x
-  - "2.2" # latest 2.2.x
+  - "2.2.5" # TODO: switch to "2.2" once it works for OS X
   - "2.3.1" # TODO: switch to "2.3" once travis fixes it
   - "ruby-head"
   - "jruby-9.0.5.0"
@@ -32,15 +32,8 @@ before_install:
 # only on versions that actually work.
 # (last tested: 2016-10)
 matrix:
-  exclude:
-    - os: osx
-      rvm: '2.2'
-    - os: osx
-      rvm: '2.3.1' # No 2.3.x at all
-
-  include:
-    - os: osx
-      rvm: '2.2.5' # Travis OS X doesn't have 2.2 aliases
+  # exclude: {}
+  # include: {}
 
   allow_failures:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - "2.3.1" # TODO: switch to "2.3" once travis fixes it
   - "ruby-head"
   - "jruby-9.0.5.0"
+  - "jruby-9.1.5.0"
   - "jruby-head"
 script:
   bundle exec rake test
@@ -42,6 +43,10 @@ matrix:
       rvm: 'jruby-head'
     - os: linux
       rvm: 'jruby-head'
+    - os: osx
+      rvm: 'jruby-9.1.5.0'
+    - os: linux
+      rvm: 'jruby-9.1.5.0'
   fast_finish: true
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 # Available ruby versions: http://rubies.travis-ci.org/
 
 language: ruby
+
 os:
   - linux
   - osx
+
 rvm:
   - "2.0.0"
   - "2.1" # latest 2.1.x
@@ -13,11 +15,14 @@ rvm:
   - "jruby-9.0.5.0"
   - "jruby-9.1.5.0"
   - "jruby-head"
+
 script:
   bundle exec rake test
+
 branches:
   except:
     - "readme-edits"
+
 before_install:
   # bundler installation needed for jruby-head
   # https://github.com/travis-ci/travis-ci/issues/5861
@@ -25,28 +30,38 @@ before_install:
 
 # Travis OS X support is pretty janky. These are some hacks to include tests
 # only on versions that actually work.
-# (last tested: 2016-04)
+# (last tested: 2016-10)
 matrix:
   exclude:
     - os: osx
       rvm: '2.2'
     - os: osx
       rvm: '2.3.1' # No 2.3.x at all
+
   include:
     - os: osx
-      rvm: '2.2.2' # Travis OS X doesn't have 2.2 aliases
+      rvm: '2.2.5' # Travis OS X doesn't have 2.2 aliases
+
   allow_failures:
+
+    # bundle fails on ruby 2.4 due to rdoc dependency on json
+    # https://github.com/flori/json/issues/303
     - rvm: 'ruby-head'
-    - os: osx
-      rvm: 'jruby-9.0.5.0'
+
+    # jruby 9.1.x.x fails tests due to bug below
     - os: osx
       rvm: 'jruby-head'
     - os: linux
       rvm: 'jruby-head'
+
+    # jruby 9.1.x.x fails tests due to jruby bug
+    # https://github.com/jruby/jruby/issues/4217
     - os: osx
       rvm: 'jruby-9.1.5.0'
     - os: linux
       rvm: 'jruby-9.1.5.0'
+
+  # return results as soon as mandatory versions are done
   fast_finish: true
 
 sudo: false


### PR DESCRIPTION
- Run `gem install bundler` for versions where travis does not automatically install it.
https://github.com/travis-ci/travis-ci/issues/5861

- Run tests on jruby 9.1.5.0, but allow failures due to a jruby bug.

- Add commentary around allowed failures.

- Use explicit 2.2.x and 2.3.x version numbers to fix builds on OS X due to travis/rvm bug.