### PR TITLE
Skip broken test on older jruby 9.1.*.* releases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,19 +41,6 @@ matrix:
     # https://github.com/flori/json/issues/303
     - rvm: 'ruby-head'
 
-    # jruby 9.1.x.x fails tests due to bug below
-    - os: osx
-      rvm: 'jruby-head'
-    - os: linux
-      rvm: 'jruby-head'
-
-    # jruby 9.1.x.x fails tests due to jruby bug
-    # https://github.com/jruby/jruby/issues/4217
-    - os: osx
-      rvm: 'jruby-9.1.5.0'
-    - os: linux
-      rvm: 'jruby-9.1.5.0'
-
   # return results as soon as mandatory versions are done
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,13 @@ before_install:
 
 # Travis OS X support is pretty janky. These are some hacks to include tests
 # only on versions that actually work.
-# (last tested: 2016-10)
+# (last tested: 2016-11)
 matrix:
   # exclude: {}
   # include: {}
 
-  allow_failures:
-
-    # bundle fails on ruby 2.4 due to rdoc dependency on json
-    # https://github.com/flori/json/issues/303
-    - rvm: 'ruby-head'
+  # allow_failures:
+    # - rvm: 'ruby-head'
 
   # return results as soon as mandatory versions are done
   fast_finish: true

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('pry', '~> 0')
   s.add_development_dependency('pry-doc', '~> 0')
-  s.add_development_dependency('rdoc', '>= 2.4.2', '< 5.0')
+  s.add_development_dependency('rdoc', '>= 2.4.2', '< 6.0')
   s.add_development_dependency('rubocop', '~> 0')
 
   s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -94,7 +94,11 @@ describe RestClient::Resource do
     expect(parent.send(:[], 'posts', &block2).block).not_to eq block1
   end
 
-  it "the block should be overrideable in ruby 1.9 syntax" do
+  # Test fails on jruby 9.1.[0-5].* due to
+  # https://github.com/jruby/jruby/issues/4217
+  it "the block should be overrideable in ruby 1.9 syntax",
+      :unless => (RUBY_ENGINE == 'jruby' && JRUBY_VERSION =~ /\A9\.1\.[0-5]\./) \
+  do
     block1 = proc {|r| r}
     block2 = ->(r) {}
 


### PR DESCRIPTION
JRuby bug should be fixed in 9.1.6.0:
https://github.com/jruby/jruby/issues/4217
