### PR TITLE
ability to have a seperate logger per thread

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -160,7 +160,17 @@ module RestClient
   @@log = nil
 
   def self.log # :nodoc:
-    @@env_log || @@log
+    local_log || @@env_log || @@log
+  end
+
+  LocalLogVariable = :restclient_local_log
+
+  def self.local_log
+    Thread.current[LocalLogVariable]
+  end
+
+  def self.local_log= logger
+    Thread.current[LocalLogVariable] = create_log logger
   end
 
   @@before_execution_procs = []


### PR DESCRIPTION
This should allow users of library to do stuff like

``` ruby
def log_request logger, &block
  RestClient.local_log = logger
  yield
ensure
  RestClient.local_log = nil
end

log_request some_logger do
  RestClient.get(...)
  RestClient.post(...)
end
```

which can help to log desired requests without having a global state.
Without this, `RestClient.log` has to be set which means all the
requests in all threads will be logged. Even if we are not interested in
logging them.
### use case

We have some important requests that we would like to log in
production. However, current implementation is not thread-safe
which means requests from other threads will be logged as well if
we set the logger.

(our app is multithreaded and uses Puma)

**Please note that this has nothing to do with the thread-safety of the
logger itself.**
