### PR TITLE
Modify log request so that it honors log formatters.

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -553,19 +553,6 @@ module RestClient
       end
     end
 
-    def log_response res
-      return unless RestClient.log
-
-      size = if @raw_response
-               File.size(@tf.path)
-             else
-               res.body.nil? ? 0 : res.body.size
-             end
-
-      RestClient.log << "# => #{res.code} #{res.class.to_s.gsub(/^Net::HTTP/, '')} | #{(res['Content-type'] || '').gsub(/;.*$/, '')} #{size} bytes\n"
->>>>>>> 224e59d... Modify log request so that it honors log formatters.
-    end
-
     # Return a hash of headers whose keys are capitalized strings
     #
     # BUG: stringify_headers does not fix the capitalization of headers that

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -545,7 +545,25 @@ module RestClient
       out << "RestClient.#{method} #{redacted_url.inspect}"
       out << payload.short_inspect if payload
       out << processed_headers.to_a.sort.map { |(k, v)| [k.inspect, v.inspect].join("=>") }.join(", ")
-      log << out.join(', ') + "\n"
+
+      if RestClient.log.respond_to?(:add)
+        RestClient.log.add(RestClient.log.level, out.join(', ') + "\n")
+      else
+        RestClient.log << out.join(', ') + "\n"
+      end
+    end
+
+    def log_response res
+      return unless RestClient.log
+
+      size = if @raw_response
+               File.size(@tf.path)
+             else
+               res.body.nil? ? 0 : res.body.size
+             end
+
+      RestClient.log << "# => #{res.code} #{res.class.to_s.gsub(/^Net::HTTP/, '')} | #{(res['Content-type'] || '').gsub(/;.*$/, '')} #{size} bytes\n"
+>>>>>>> 224e59d... Modify log request so that it honors log formatters.
     end
 
     # Return a hash of headers whose keys are capitalized strings

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -546,10 +546,10 @@ module RestClient
       out << payload.short_inspect if payload
       out << processed_headers.to_a.sort.map { |(k, v)| [k.inspect, v.inspect].join("=>") }.join(", ")
 
-      if RestClient.log.respond_to?(:add)
-        RestClient.log.add(RestClient.log.level, out.join(', ') + "\n")
+      if log.respond_to?(:add)
+        log.add(log.level, out.join(', ') + "\n")
       else
-        RestClient.log << out.join(', ') + "\n"
+        log << out.join(', ') + "\n"
       end
     end
 


### PR DESCRIPTION
I would like to use a custom Logger object for RestClient.log. While RestClient.log accepts a Logger instance, the problem is that it doesn't honor any log formatting that I apply. This is because you use the `<<` method to add data to the log within the `log_request` method. Unfortunately, the `Logger#<<` method ignores formatting:

http://ruby-doc.org/stdlib-2.3.1/libdoc/logger/rdoc/Logger.html#method-i-3C-3C

This PR modifies the log_request code so that it resorts to using the `add` method if defined. By using this method instead it will honor any custom formatting that I applied to the logger instance.

I need this mostly because I need to filter out Bearer token information from the authorization header, but also because I wanted to modify the default timestamp, and other little things, e.g. something like this:

```
logger = Logger.new(STDOUT)
logger.datetime_format = '%Y-%m-%d %H:%M:%S'

logger.formatter = proc do |severity, datetime, progname, msg|
  msg = msg.sub /Bearer(.*?)\"/, 'Bearer [FILTERED]"'
  "[#{datetime}] - #{severity} -- : #{msg}"
end

RestClient.log = logger
```
