### PR TITLE
[#496] added log_level functionality

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -118,6 +118,10 @@ module RestClient
     @@log = create_log log
   end
 
+  def self.log_level= log_level
+    @@log_level = log_level.to_sym
+  end
+
   # Create a log that respond to << like a logger
   # param can be 'stdout', 'stderr', a string (then we will log to that file) or a logger (then we return it)
   def self.create_log param
@@ -156,11 +160,24 @@ module RestClient
   end
 
   @@env_log = create_log ENV['RESTCLIENT_LOG']
-
+  @@env_log_level = ENV['RESTCLIENT_LOG_LEVEL']
   @@log = nil
+  @@log_level = :default
 
   def self.log # :nodoc:
     @@env_log || @@log
+  end
+
+  def self.log_level
+    @@env_log_level || @@log_level || :default
+  end
+
+  def self.log_level_request_info?
+    log_level == :request || log_level == :default
+  end
+
+  def self.log_level_response_info?
+    log_level == :response || log_level == :default
   end
 
   @@before_execution_procs = []

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -578,6 +578,7 @@ module RestClient
 
     def log_request
       return unless RestClient.log
+      return unless RestClient.log_level_request_info?
 
       out = []
 
@@ -589,6 +590,7 @@ module RestClient
 
     def log_response res
       return unless RestClient.log
+      return unless RestClient.log_level_response_info?
 
       size = if @raw_response
                File.size(@tf.path)

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -21,6 +21,7 @@ describe RestClient::Request, :include_helpers do
     allow(@net).to receive(:ciphers=)
     allow(@net).to receive(:cert_store=)
     RestClient.log = nil
+    RestClient.log_level = :default
   end
 
   it "accept */* mimetype" do
@@ -656,6 +657,32 @@ describe RestClient::Request, :include_helpers do
 
     it 'does not log request password' do
       log = RestClient.log = []
+      RestClient::Request.new(:method => :get, :url => 'http://user:password@url', :headers => {:user_agent => 'rest-client'}).log_request
+      expect(log[0]).to eq %Q{RestClient.get "http://user:REDACTED@url", "Accept"=>"*/*", "Accept-Encoding"=>"gzip, deflate", "User-Agent"=>"rest-client"\n}
+    end
+
+    it 'does not log response if log_level is request' do
+      log = RestClient.log = []
+      RestClient.log_level = 'request'
+      res = double('result', :code => '200', :class => Net::HTTPOK, :body => 'abcd')
+      allow(res).to receive(:[]).with('Content-type').and_return(nil)
+      @request.log_response res
+      expect(log[0]).to eq nil
+    end
+
+    it 'does not log request if log_level is response' do
+      log = RestClient.log = []
+      RestClient.log_level = 'response'
+      RestClient::Request.new(:method => :get, :url => 'http://user:password@url', :headers => {:user_agent => 'rest-client'}).log_request
+      expect(log[0]).to eq nil
+    end
+
+    it 'does not log request/response if log_level is other than :default' do
+      log = RestClient.log = []
+      RestClient.log_level = 'test'
+      RestClient::Request.new(:method => :get, :url => 'http://user:password@url', :headers => {:user_agent => 'rest-client'}).log_request
+      expect(log[0]).to eq nil
+      RestClient.log_level = 'default'
       RestClient::Request.new(:method => :get, :url => 'http://user:password@url', :headers => {:user_agent => 'rest-client'}).log_request
       expect(log[0]).to eq %Q{RestClient.get "http://user:REDACTED@url", "Accept"=>"*/*", "Accept-Encoding"=>"gzip, deflate", "User-Agent"=>"rest-client"\n}
     end


### PR DESCRIPTION
Added log level functionality
Added `Restclient.log_level` or `ENV['RESTCLIENT_LOG_LEVEL']` for the log level values.
 `# Reclient.log_level = :default or :request  or : response`
