### PR TITLE
PERF: Eliminate dependency on mime-types gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ updates.
 
 The rest-client gem depends on these other gems for usage at runtime:
 
-* [mime-types](http://rubygems.org/gems/mime-types)
+* [mini-mime](http://rubygems.org/gems/mini-mime)
 * [netrc](http://rubygems.org/gems/netrc)
 * [http-cookie](https://rubygems.org/gems/http-cookie)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ updates.
 
 The rest-client gem depends on these other gems for usage at runtime:
 
-* [mini-mime](http://rubygems.org/gems/mini-mime)
+* [mini_mime](http://rubygems.org/gems/mini_mime)
 * [netrc](http://rubygems.org/gems/netrc)
 * [http-cookie](https://rubygems.org/gems/http-cookie)
 

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -2,7 +2,7 @@ require 'tempfile'
 require 'securerandom'
 require 'stringio'
 
-require 'mime/types'
+require 'mini_mime'
 
 module RestClient
   module Payload
@@ -169,8 +169,8 @@ module RestClient
       end
 
       def mime_for(path)
-        mime = MIME::Types.type_for path
-        mime.empty? ? 'text/plain' : mime[0].content_type
+        mime = MiniMime.lookup_by_filename path
+        mime ? mime.content_type : 'text/plain'
       end
 
       def boundary

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -1,5 +1,5 @@
 require 'tempfile'
-require 'mime/types'
+require 'mini_mime'
 require 'cgi'
 require 'netrc'
 require 'set'
@@ -912,12 +912,8 @@ module RestClient
         return ext
       end
 
-      types = MIME::Types.type_for(ext)
-      if types.empty?
-        ext
-      else
-        types.first.content_type
-      end
+      type = MiniMime.lookup_by_filename("a.#{ext}")
+      type ? type.content_type : ext
     end
   end
 end

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~> 0')
 
   s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
-  s.add_dependency('mime-types', '>= 1.16', '< 4.0')
+  s.add_dependency('mini_mime', '>= 0.1.1')
   s.add_dependency('netrc', '~> 0.8')
 
   s.required_ruby_version = '>= 2.0.0'


### PR DESCRIPTION
The mime types gem (even with the magical columnar store by @jeremyevans) is a **memory hog**.

In particular on boot, mime/types/columnar will allocate **109k** objects and end up with a retained count of **31K** objects. 

This bloat leaves objects that need to be marked and swept every major GC and bloats ruby processes. 

To circumvent mini_mime was created. 

It uses the exact same database as the full fledged mime types and is capable of only loading stuff on demand with a practical, safe and bound in-memory cache. 

mini_mime will allocate **398** objects on boot and only retain **62** (due to rubygems inefficiency) 

In table form:

| |boot allocations|boot retained|lookup|lookup uncached|
|-|-:|-:|-:|-:|
|mini_mime|398|62|641K/s|33K/s|
|mime-types|109796|31165|361K/s|361K/s|

The performance of mini_mime is pretty good, cached lookups are faster than the mime types gem and uncached lookups are 10x slower. (which is really not a huge issue considering the memory savings)


