### PR TITLE
Fix compatility with Ruby OpenSSL 2.x+.

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -195,7 +195,7 @@ module RestClient
           # If we're on a Ruby version that has insecure default ciphers,
           # override it with our default list.
           if WeakDefaultCiphers.include?(
-               OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.fetch(:ciphers))
+               OpenSSL::SSL::SSLContext.new.ciphers)
             @ssl_opts[:ciphers] = DefaultCiphers
           end
         end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -927,15 +927,10 @@ describe RestClient::Request, :include_helpers do
     end
 
     it "should override ssl_ciphers with better defaults with weak default ciphers" do
-      stub_const(
-        '::OpenSSL::SSL::SSLContext::DEFAULT_PARAMS',
-        {
-          :ssl_version=>"SSLv23",
-          :verify_mode=>1,
-          :ciphers=>"ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW",
-          :options=>-2147480577,
-        }
-      )
+      expect(RestClient::Request::WeakDefaultCiphers)
+        .to receive(:include?)
+        .with(OpenSSL::SSL::SSLContext.new.ciphers)
+        .and_return(true)
 
       @request = RestClient::Request.new(
         :method => :put,
@@ -952,15 +947,10 @@ describe RestClient::Request, :include_helpers do
     end
 
     it "should not override ssl_ciphers with better defaults with different default ciphers" do
-      stub_const(
-        '::OpenSSL::SSL::SSLContext::DEFAULT_PARAMS',
-        {
-          :ssl_version=>"SSLv23",
-          :verify_mode=>1,
-          :ciphers=>"HIGH:!aNULL:!eNULL:!EXPORT:!LOW:!MEDIUM:!SSLv2",
-          :options=>-2147480577,
-        }
-      )
+      expect(RestClient::Request::WeakDefaultCiphers)
+        .to receive(:include?)
+        .with(OpenSSL::SSL::SSLContext.new.ciphers)
+        .and_return(false)
 
       @request = RestClient::Request.new(
         :method => :put,


### PR DESCRIPTION
The DEFAULT_PARAMS does not list the ciphers anymore:

https://github.com/ruby/openssl/commit/b9aea270fbe1b3f8e806e86a28d8a27e242ab251

But honestly, I'd be much happier if the WeakDefaultCiphers and DefaultCiphers lists were removed entirely, since this is at least 4th layer which is changing the cipher settings.

1. OpenSSL itself
2. Operating system defaults and policies [[1]]
3. Ruby
4. rest-client

At the end, nobody knows what the settings is. It seems that at least Ruby itself is going to stick with the defaults underneath, would be nice if rest-cliend did the same.

[1]: https://fedoraproject.org/wiki/Packaging:CryptoPolicies