### PR TITLE
Drop check for weak default TLS ciphers.

### DIFF
--- a/history.md
+++ b/history.md
@@ -3,6 +3,9 @@
 - Warn if auto-generated headers from the payload, such as Content-Type,
   override headers set by the user. (This is usually not what the user wants to
   happen, and can be surprising.)
+- Drop the old check for weak default TLS ciphers, and use the built-in Ruby
+  defaults. Ruby versions from Oct. 2014 onward use sane defaults, so this is
+  no longer needed. (#573)
 
 # 2.0.0
 

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -52,67 +52,6 @@ module RestClient
       new(args).execute(& block)
     end
 
-    # This is similar to the list now in ruby core, but adds HIGH for better
-    # compatibility (similar to Firefox) and moves AES-GCM cipher suites above
-    # DHE/ECDHE CBC suites (similar to Chromium).
-    # https://github.com/ruby/ruby/commit/699b209cf8cf11809620e12985ad33ae33b119ee
-    #
-    # This list will be used by default if the Ruby global OpenSSL default
-    # ciphers appear to be a weak list.
-    #
-    # TODO: either remove this code or always use it, since Ruby uses a decent
-    # cipher list in versions >= 2.0.
-    #
-    DefaultCiphers = %w{
-      !aNULL
-      !eNULL
-      !EXPORT
-      !SSLV2
-      !LOW
-
-      ECDHE-ECDSA-AES128-GCM-SHA256
-      ECDHE-RSA-AES128-GCM-SHA256
-      ECDHE-ECDSA-AES256-GCM-SHA384
-      ECDHE-RSA-AES256-GCM-SHA384
-      DHE-RSA-AES128-GCM-SHA256
-      DHE-DSS-AES128-GCM-SHA256
-      DHE-RSA-AES256-GCM-SHA384
-      DHE-DSS-AES256-GCM-SHA384
-      AES128-GCM-SHA256
-      AES256-GCM-SHA384
-      ECDHE-ECDSA-AES128-SHA256
-      ECDHE-RSA-AES128-SHA256
-      ECDHE-ECDSA-AES128-SHA
-      ECDHE-RSA-AES128-SHA
-      ECDHE-ECDSA-AES256-SHA384
-      ECDHE-RSA-AES256-SHA384
-      ECDHE-ECDSA-AES256-SHA
-      ECDHE-RSA-AES256-SHA
-      DHE-RSA-AES128-SHA256
-      DHE-RSA-AES256-SHA256
-      DHE-RSA-AES128-SHA
-      DHE-RSA-AES256-SHA
-      DHE-DSS-AES128-SHA256
-      DHE-DSS-AES256-SHA256
-      DHE-DSS-AES128-SHA
-      DHE-DSS-AES256-SHA
-      AES128-SHA256
-      AES256-SHA256
-      AES128-SHA
-      AES256-SHA
-      ECDHE-ECDSA-RC4-SHA
-      ECDHE-RSA-RC4-SHA
-      RC4-SHA
-
-      HIGH
-      +RC4
-    }.join(":")
-
-    # A set of weak default ciphers that we will override by default.
-    WeakDefaultCiphers = Set.new([
-      "ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW",
-    ])
-
     SSLOptionList = %w{client_cert client_key ca_file ca_path cert_store
                        version ciphers verify_callback verify_callback_warnings}
 
@@ -189,15 +128,6 @@ module RestClient
         # If there's no CA file, CA path, or cert store provided, use default
         if !ssl_ca_file && !ssl_ca_path && !@ssl_opts.include?(:cert_store)
           @ssl_opts[:cert_store] = self.class.default_ssl_cert_store
-        end
-
-        unless @ssl_opts.include?(:ciphers)
-          # If we're on a Ruby version that has insecure default ciphers,
-          # override it with our default list.
-          if WeakDefaultCiphers.include?(
-               OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.fetch(:ciphers))
-            @ssl_opts[:ciphers] = DefaultCiphers
-          end
         end
       end
 

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -926,56 +926,6 @@ describe RestClient::Request, :include_helpers do
       @request.send(:transmit, @uri, 'req', 'payload')
     end
 
-    it "should override ssl_ciphers with better defaults with weak default ciphers" do
-      stub_const(
-        '::OpenSSL::SSL::SSLContext::DEFAULT_PARAMS',
-        {
-          :ssl_version=>"SSLv23",
-          :verify_mode=>1,
-          :ciphers=>"ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW",
-          :options=>-2147480577,
-        }
-      )
-
-      @request = RestClient::Request.new(
-        :method => :put,
-        :url => 'https://some/resource',
-        :payload => 'payload',
-      )
-
-      expect(@net).to receive(:ciphers=).with(RestClient::Request::DefaultCiphers)
-
-      allow(@http).to receive(:request)
-      allow(@request).to receive(:process_result)
-      allow(@request).to receive(:response_log)
-      @request.send(:transmit, @uri, 'req', 'payload')
-    end
-
-    it "should not override ssl_ciphers with better defaults with different default ciphers" do
-      stub_const(
-        '::OpenSSL::SSL::SSLContext::DEFAULT_PARAMS',
-        {
-          :ssl_version=>"SSLv23",
-          :verify_mode=>1,
-          :ciphers=>"HIGH:!aNULL:!eNULL:!EXPORT:!LOW:!MEDIUM:!SSLv2",
-          :options=>-2147480577,
-        }
-      )
-
-      @request = RestClient::Request.new(
-        :method => :put,
-        :url => 'https://some/resource',
-        :payload => 'payload',
-      )
-
-      expect(@net).not_to receive(:ciphers=)
-
-      allow(@http).to receive(:request)
-      allow(@request).to receive(:process_result)
-      allow(@request).to receive(:response_log)
-      @request.send(:transmit, @uri, 'req', 'payload')
-    end
-
     it "should set the ssl_client_cert if provided" do
       @request = RestClient::Request.new(
               :method => :put,


### PR DESCRIPTION
Ruby versions from 2.0.0-p594 (Oct. 2014) and newer will have a
relatively sane cipher list, so there's no need to override for the vast
majority of supported versions of Ruby.

Older versions of Ruby (no longer supported by security patches) have
bigger problems than their cipher lists being insecure.

This addresses compatibility with newer versions of OpenSSL (1.1.0).

Fixes: #569