### PR TITLE
Fix bug where RestClient would warn even if header was set correctly according to payload

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -373,7 +373,7 @@ module RestClient
         # x-www-form-urlencoded but a Content-Type application/json was
         # also supplied by the user.
         payload_headers.each_pair do |key, val|
-          if headers.include?(key)
+          if headers.include?(key) && headers[key] != val
             warn("warning: Overriding #{key.inspect} header " +
                  "#{headers.fetch(key).inspect} with #{val.inspect} " +
                  "due to payload")

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -280,6 +280,13 @@ describe RestClient::Request, :include_helpers do
     }).to match(/warning: Overriding "Content-Length" header/i)
   end
 
+  it "does not warn when overriding user header with payload header if the contents of those headers were identical" do
+    expect(fake_stderr {
+      RestClient::Request.new(method: :post, url: 'example.com',
+                              payload: {'foo' => '123456'}, headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })
+    }).not_to match(/warning: Overriding "Content-Type" header/i)
+  end
+
   it 'does not warn for a normal looking payload' do
     expect(fake_stderr {
       RestClient::Request.new(method: :post, url: 'example.com', payload: 'payload')

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -280,7 +280,7 @@ describe RestClient::Request, :include_helpers do
     }).to match(/warning: Overriding "Content-Length" header/i)
   end
 
-  it "does not warn when overriding user header with payload header if the contents of those headers were identical" do
+  it "does not warn when overriding user header with header derived from payload if those header values were identical" do
     expect(fake_stderr {
       RestClient::Request.new(method: :post, url: 'example.com',
                               payload: {'foo' => '123456'}, headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })


### PR DESCRIPTION
Fix bug 'warning: Overriding 'Content-Type' header 'application/x-www-form-urlencoded' with 'application/x-www-form-urlencoded' due to payload.