### PR TITLE
Remove duplicate require

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -1,7 +1,6 @@
 require 'net/http'
 require 'openssl'
 require 'stringio'
-require 'uri'
 require 'zlib'
 
 require File.dirname(__FILE__) + '/restclient/version'


### PR DESCRIPTION
Net http already requires 'uri' internally. No need to duplicate it.