### PR TITLE
Use IO.copy_stream when generating multipart body

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -160,9 +160,7 @@ module RestClient
           s.write(" filename=\"#{v.respond_to?(:original_filename) ? v.original_filename : File.basename(v.path)}\"#{EOL}")
           s.write("Content-Type: #{v.respond_to?(:content_type) ? v.content_type : mime_for(v.path)}#{EOL}")
           s.write(EOL)
-          while (data = v.read(8124))
-            s.write(data)
-          end
+          IO.copy_stream(v, s)
         ensure
           v.close if v.respond_to?(:close)
         end


### PR DESCRIPTION
IO.copy_stream is shorter and more efficient way of copying data from one IO object to another, because for MRI is written in C, and because it's implemented in a way that every new chunk overwrites the previous, so instead of creating a new string from each chunk, the previous chunk string is replaced by the new one. It's the equivalent of passing a second "buffer" argument to `IO#read`:

```rb
buffer = ""
while (data = v.read(8124, buffer))
  s.write(data)
end
```