### PR TITLE
Add test for :timeout + :open_timeout combo behaving same as <2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Overview of significant changes:
 * requires Ruby >= 2.0
 * `RestClient::Response` objects are a subclass of `String` rather than a
   Frankenstein monster. And `#body` or `#to_s` return a true `String` object.
-* cleanup of exception classes, including new `RestClient::Exceptions::Timeout`
+* cleanup of exception classes, including new `RestClient::Exceptions::Timeout`.
+* `:timeout` option renamed `:read_timeout`.
 * improvements to handling of redirects: responses and history are properly
   exposed
 * major changes to cookie support: cookie jars are used for browser-like

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -744,6 +744,20 @@ describe RestClient::Request, :include_helpers do
       @request.send(:transmit, @uri, 'req', nil)
     end
 
+    it 'handles :timeout with :open_timeout compatibly to 1.x' do
+      # Just a special case of :open_timeout winning, but helpful for code
+      # written before :timeout -> :read_timeout rename.
+      @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => 123, :open_timeout => 34)
+      allow(@http).to receive(:request)
+      allow(@request).to receive(:process_result)
+      allow(@request).to receive(:response_log)
+
+      expect(@net).to receive(:open_timeout=).with(34)
+      expect(@net).to receive(:read_timeout=).with(123)
+
+      @request.send(:transmit, @uri, 'req', nil)
+    end
+
     it 'supersedes :timeout with open/read_timeout' do
       @request = RestClient::Request.new(:method => :put, :url => 'http://some/resource', :payload => 'payload', :timeout => 123, :open_timeout => 34, :read_timeout => 56)
       allow(@http).to receive(:request)


### PR DESCRIPTION
This is already how it behaves, just a special case of open/read_timeout
superseding :timeout.  But I want to rely on it in another lib
(https://github.com/abonas/kubeclient/pull/244) which currently kinda
supports both RestClient 1.x and 2.0...
(We'll bump to RestClient 2.0 at some point but I don't want to tie this together.)
Do you mind adding this test?

I've confirmed that same test cherry-picked onto 1.6-legacy, 1.7, 1.8 passes too (no surprise, it's essentially same as existing tests for setting both timeouts there).