### PR TITLE
Track start/end times on response objects.

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -36,6 +36,9 @@ module RestClient
       @raw_headers ||= @net_http_res.to_hash
     end
 
+    # @param [Net::HTTPResponse] net_http_res
+    # @param [RestClient::Request] request
+    # @param [Time] start_time
     def response_set_vars(net_http_res, request, start_time)
       @net_http_res = net_http_res
       @request = request

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -5,7 +5,7 @@ module RestClient
 
   module AbstractResponse
 
-    attr_reader :net_http_res, :request
+    attr_reader :net_http_res, :request, :start_time, :end_time, :duration
 
     def inspect
       raise NotImplementedError.new('must override in subclass')
@@ -31,9 +31,18 @@ module RestClient
       @raw_headers ||= @net_http_res.to_hash
     end
 
-    def response_set_vars(net_http_res, request)
+    def response_set_vars(net_http_res, request, start_time)
       @net_http_res = net_http_res
       @request = request
+      @start_time = start_time
+      @end_time = Time.now
+
+      if @start_time
+        @duration = @end_time - @start_time
+      else
+        warn 'deprecation warning: Response object created without start_time'
+        @duration = nil
+      end
 
       # prime redirection history
       history

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -16,6 +16,16 @@ module RestClient
       request.log
     end
 
+    def log_response
+      return unless log
+
+      code = net_http_res.code
+      res_name = net_http_res.class.to_s.gsub(/\ANet::HTTP/, '')
+      content_type = (net_http_res['Content-type'] || '').gsub(/;.*\z/, '')
+
+      log << "# => #{code} #{res_name} | #{content_type} #{size} bytes, #{sprintf('%.2f', duration)}s\n"
+    end
+
     # HTTP status code
     def code
       @code ||= @net_http_res.code.to_i
@@ -48,7 +58,6 @@ module RestClient
       if @start_time
         @duration = @end_time - @start_time
       else
-        warn 'deprecation warning: Response object created without start_time'
         @duration = nil
       end
 

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -11,6 +11,11 @@ module RestClient
       raise NotImplementedError.new('must override in subclass')
     end
 
+    # Logger from the request, potentially nil.
+    def log
+      request.log
+    end
+
     # HTTP status code
     def code
       @code ||= @net_http_res.code.to_i

--- a/lib/restclient/raw_response.rb
+++ b/lib/restclient/raw_response.rb
@@ -19,8 +19,15 @@ module RestClient
       "<RestClient::RawResponse @code=#{code.inspect}, @file=#{file.inspect}, @request=#{request.inspect}>"
     end
 
+    # @param [Tempfile] tempfile The temporary file containing the body
+    # @param [Net::HTTPResponse] net_http_res
+    # @param [RestClient::Request] request
+    # @param [Time] start_time
     def initialize(tempfile, net_http_res, request, start_time=nil)
       @file = tempfile
+
+      # reopen the tempfile so we can read it
+      @file.open
 
       response_set_vars(net_http_res, request, start_time)
     end
@@ -30,7 +37,7 @@ module RestClient
     end
 
     def body
-      @file.open
+      @file.rewind
       @file.read
     end
 

--- a/lib/restclient/raw_response.rb
+++ b/lib/restclient/raw_response.rb
@@ -13,25 +13,29 @@ module RestClient
 
     include AbstractResponse
 
-    attr_reader :file, :request
+    attr_reader :file, :request, :start_time, :end_time
 
     def inspect
       "<RestClient::RawResponse @code=#{code.inspect}, @file=#{file.inspect}, @request=#{request.inspect}>"
     end
 
-    def initialize(tempfile, net_http_res, request)
-      @net_http_res = net_http_res
+    def initialize(tempfile, net_http_res, request, start_time=nil)
       @file = tempfile
-      @request = request
+
+      response_set_vars(net_http_res, request, start_time)
     end
 
     def to_s
+      body
+    end
+
+    def body
       @file.open
       @file.read
     end
 
     def size
-      File.size file
+      file.size
     end
 
   end

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -553,18 +553,6 @@ module RestClient
       log << out.join(', ') + "\n"
     end
 
-    def log_response(net_http_res, response)
-      return unless log
-
-      duration = response.duration
-
-      code = net_http_res.code
-      res_name = net_http_res.class.to_s.split('::').last
-      content_type = (net_http_res['Content-type'] || '').gsub(/;.*\z/, '')
-
-      log << "# => #{code} #{res_name} | #{content_type} #{response.size} bytes, #{sprintf('%.2f', duration)}s\n"
-    end
-
     # Return a hash of headers whose keys are capitalized strings
     def stringify_headers headers
       headers.inject({}) do |result, (key, value)|
@@ -824,7 +812,7 @@ module RestClient
 
     # @param res The Net::HTTP response object
     # @param start_time [Time] Time of request start
-    def process_result(res, start_time, tempfile, &block)
+    def process_result(res, start_time, tempfile=nil, &block)
       if @raw_response
         # We don't decode raw requests
         response = RawResponse.new(tempfile, res, self, start_time)
@@ -833,7 +821,7 @@ module RestClient
         response = Response.create(decoded, res, self, start_time)
       end
 
-      log_response(res, response)
+      response.log_response
 
       if block_given?
         block.call(response, self, res, & block)

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -98,6 +98,12 @@ module RestClient
       @block_response = args[:block_response]
       @raw_response = args[:raw_response] || false
 
+      @stream_log_percent = args[:stream_log_percent] || 10
+      if @stream_log_percent <= 0 || @stream_log_percent > 100
+        raise ArgumentError.new(
+          "Invalid :stream_log_percent #{@stream_log_percent.inspect}")
+      end
+
       @proxy = args.fetch(:proxy) if args.include?(:proxy)
 
       @ssl_opts = {}
@@ -138,7 +144,6 @@ module RestClient
       end
 
       @log = args[:log]
-      @tf = nil # If you are a raw request, this is your tempfile
       @max_redirects = args[:max_redirects] || 10
       @processed_headers = make_headers headers
       @args = args
@@ -548,16 +553,16 @@ module RestClient
       log << out.join(', ') + "\n"
     end
 
-    def log_response res
+    def log_response(net_http_res, response)
       return unless log
 
-      size = if @raw_response
-               File.size(@tf.path)
-             else
-               res.body.nil? ? 0 : res.body.size
-             end
+      duration = response.duration
 
-      log << "# => #{res.code} #{res.class.to_s.gsub(/^Net::HTTP/, '')} | #{(res['Content-type'] || '').gsub(/;.*$/, '')} #{size} bytes\n"
+      code = net_http_res.code
+      res_name = net_http_res.class.to_s.split('::').last
+      content_type = (net_http_res['Content-type'] || '').gsub(/;.*\z/, '')
+
+      log << "# => #{code} #{res_name} | #{content_type} #{response.size} bytes, #{sprintf('%.2f', duration)}s\n"
     end
 
     # Return a hash of headers whose keys are capitalized strings
@@ -724,6 +729,9 @@ module RestClient
 
       log_request
 
+      start_time = Time.now
+      tempfile = nil
+
       net.start do |http|
         established_connection = true
 
@@ -731,10 +739,16 @@ module RestClient
           net_http_do_request(http, req, payload, &@block_response)
         else
           res = net_http_do_request(http, req, payload) { |http_response|
-            fetch_body(http_response)
+            if @raw_response
+              # fetch body into tempfile
+              tempfile = fetch_body_to_tempfile(http_response)
+            else
+              # fetch body
+              http_response.read_body
+            end
+            http_response
           }
-          log_response res
-          process_result res, & block
+          process_result(res, start_time, tempfile, &block)
         end
       end
     rescue EOFError
@@ -777,43 +791,52 @@ module RestClient
       req.basic_auth(user, password) if user && !headers.has_key?("Authorization")
     end
 
-    def fetch_body(http_response)
-      if @raw_response
-        # Taken from Chef, which as in turn...
-        # Stolen from http://www.ruby-forum.com/topic/166423
-        # Kudos to _why!
-        @tf = Tempfile.new('rest-client.')
-        @tf.binmode
-        size, total = 0, http_response['Content-Length'].to_i
-        http_response.read_body do |chunk|
-          @tf.write chunk
-          size += chunk.size
-          if log
-            if size == 0
-              log << "%s %s done (0 length file)\n" % [@method, @url]
-            elsif total == 0
-              log << "%s %s (zero content length)\n" % [@method, @url]
-            else
-              log << "%s %s %d%% done (%d of %d)\n" % [@method, @url, (size * 100) / total, size, total]
+    def fetch_body_to_tempfile(http_response)
+      # Taken from Chef, which as in turn...
+      # Stolen from http://www.ruby-forum.com/topic/166423
+      # Kudos to _why!
+      tf = Tempfile.new('rest-client.')
+      tf.binmode
+
+      size = 0
+      total = http_response['Content-Length'].to_i
+      stream_log_bucket = nil
+
+      http_response.read_body do |chunk|
+        tf.write chunk
+        size += chunk.size
+        if log
+          if total == 0
+            log << "streaming %s %s (%d of unknown) [0 Content-Length]\n" % [@method.upcase, @url, size]
+          else
+            percent = (size * 100) / total
+            current_log_bucket, _ = percent.divmod(@stream_log_percent)
+            if current_log_bucket != stream_log_bucket
+              stream_log_bucket = current_log_bucket
+              log << "streaming %s %s %d%% done (%d of %d)\n" % [@method.upcase, @url, (size * 100) / total, size, total]
             end
           end
         end
-        @tf.close
-        @tf
-      else
-        http_response.read_body
       end
-      http_response
+      tf.close
+      tf
     end
 
-    def process_result res, & block
+    # @param res The Net::HTTP response object
+    # @param start_time [Time] Time of request start
+    def process_result(res, start_time, tempfile, &block)
       if @raw_response
+        unless tempfile
+          raise ArgumentError.new('tempfile required if @raw_response true')
+        end
         # We don't decode raw requests
-        response = RawResponse.new(@tf, res, self)
+        response = RawResponse.new(tempfile, res, self, start_time)
       else
         decoded = Request.decode(res['content-encoding'], res.body)
-        response = Response.create(decoded, res, self)
+        response = Response.create(decoded, res, self, start_time)
       end
+
+      log_response(res, response)
 
       if block_given?
         block.call(response, self, res, & block)

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -826,9 +826,6 @@ module RestClient
     # @param start_time [Time] Time of request start
     def process_result(res, start_time, tempfile, &block)
       if @raw_response
-        unless tempfile
-          raise ArgumentError.new('tempfile required if @raw_response true')
-        end
         # We don't decode raw requests
         response = RawResponse.new(tempfile, res, self, start_time)
       else

--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -42,10 +42,10 @@ module RestClient
       request.log
     end
 
-    def self.create(body, net_http_res, request)
+    def self.create(body, net_http_res, request, start_time=nil)
       result = self.new(body || '')
 
-      result.response_set_vars(net_http_res, request)
+      result.response_set_vars(net_http_res, request, start_time)
       fix_encoding(result)
 
       result

--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -38,10 +38,6 @@ module RestClient
       "<RestClient::Response #{code.inspect} #{body_truncated(10).inspect}>"
     end
 
-    def log
-      request.log
-    end
-
     def self.create(body, net_http_res, request, start_time=nil)
       result = self.new(body || '')
 

--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -38,6 +38,14 @@ module RestClient
       "<RestClient::Response #{code.inspect} #{body_truncated(10).inspect}>"
     end
 
+    # Initialize a Response object. Because RestClient::Response is
+    # (unfortunately) a subclass of String for historical reasons,
+    # Response.create is the preferred initializer.
+    #
+    # @param [String, nil] body The response body from the Net::HTTPResponse
+    # @param [Net::HTTPResponse] net_http_res
+    # @param [RestClient::Request] request
+    # @param [Time] start_time
     def self.create(body, net_http_res, request, start_time=nil)
       result = self.new(body || '')
 
@@ -47,6 +55,8 @@ module RestClient
       result
     end
 
+    # Set the String encoding according to the 'Content-Type: charset' header,
+    # if possible.
     def self.fix_encoding(response)
       charset = RestClient::Utils.get_encoding_from_headers(response.headers)
       encoding = nil

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,8 +1,20 @@
 require 'uri'
 
 module Helpers
-  def response_double(opts={})
-    double('response', {:to_hash => {}}.merge(opts))
+  def res_double(opts={})
+    double('Net::HTTPResponse', {to_hash: {}, body: 'response body'}.merge(opts))
+  end
+
+  def response_from_res_double(net_http_res_double, request=nil, duration: 1)
+    request ||= request_double()
+    start_time = Time.now - duration
+
+    response = RestClient::Response.create(net_http_res_double.body, net_http_res_double, request, start_time)
+
+    # mock duration to ensure it gets the value we expect
+    allow(response).to receive(:duration).and_return(duration)
+
+    response
   end
 
   def fake_stderr

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,10 +1,23 @@
 require 'uri'
 
 module Helpers
+
+  # @param [Hash] opts A hash of methods, passed directly to the double
+  #   definition. Use this to stub other required methods.
+  #
+  # @return double for Net::HTTPResponse
   def res_double(opts={})
-    double('Net::HTTPResponse', {to_hash: {}, body: 'response body'}.merge(opts))
+    instance_double('Net::HTTPResponse', {to_hash: {}, body: 'response body'}.merge(opts))
   end
 
+  # Given a Net::HTTPResponse or double and a Request or double, create a
+  # RestClient::Response object.
+  #
+  # @param net_http_res_double an rspec double for Net::HTTPResponse
+  # @param request A RestClient::Request or rspec double
+  #
+  # @return [RestClient::Response]
+  #
   def response_from_res_double(net_http_res_double, request=nil, duration: 1)
     request ||= request_double()
     start_time = Time.now - duration
@@ -17,6 +30,7 @@ module Helpers
     response
   end
 
+  # Redirect stderr to a string for the duration of the passed block.
   def fake_stderr
     original_stderr = $stderr
     $stderr = StringIO.new
@@ -26,9 +40,11 @@ module Helpers
     $stderr = original_stderr
   end
 
+  # Create a double for RestClient::Request
   def request_double(url: 'http://example.com', method: 'get')
-    double('request', url: url, uri: URI.parse(url), method: method,
-           user: nil, password: nil, cookie_jar: HTTP::CookieJar.new,
-           redirection_history: nil, args: {url: url, method: method})
+    instance_double('RestClient::Request',
+      url: url, uri: URI.parse(url), method: method, user: nil, password: nil,
+      cookie_jar: HTTP::CookieJar.new, redirection_history: nil,
+      args: {url: url, method: method})
   end
 end

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -135,7 +135,7 @@ describe RestClient::AbstractResponse, :include_helpers do
     end
 
     it "should gracefully handle 302 redirect with no location header" do
-      @net_http_res = response_double(code: 302, location: nil)
+      @net_http_res = res_double(code: 302, location: nil)
       @request = request_double()
       @response = MyAbstractResponse.new(@net_http_res, @request)
       expect(@response).to receive(:check_max_redirects).and_return('fake-check')

--- a/spec/unit/raw_response_spec.rb
+++ b/spec/unit/raw_response_spec.rb
@@ -2,9 +2,9 @@ require_relative '_lib'
 
 describe RestClient::RawResponse do
   before do
-    @tf = double("Tempfile", :read => "the answer is 42", :open => true)
+    @tf = double("Tempfile", :read => "the answer is 42", :open => true, :rewind => true)
     @net_http_res = double('net http response')
-    @request = double('http request')
+    @request = double('restclient request', :redirection_history => nil)
     @response = RestClient::RawResponse.new(@tf, @net_http_res, @request)
   end
 
@@ -14,5 +14,9 @@ describe RestClient::RawResponse do
 
   it "exposes a Tempfile" do
     expect(@response.file).to eq @tf
+  end
+
+  it "includes AbstractResponse" do
+    expect(RestClient::RawResponse.ancestors).to include(RestClient::AbstractResponse)
   end
 end


### PR DESCRIPTION
Record the start and end times of a request (from the time just before the
request is initiated to the time that the response object is created). Log
the duration when we log the end of the request.

Other miscellaneous changes:

Refactor the handling of `:raw_response => true` / streaming requests to be a
little less awkward, and create a uniform `#size` method regardless of whether
the response is a Response or RawResponse. Also always reopen the tempfile for
reading, since users presumably want to read the response.

Move `#log_response` to be a method of Response objects, not Request objects.

Clean up tests slightly.


Fixes: #126