### PR TITLE
#read_timeout, #open_timeout always return effective values

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -61,6 +61,9 @@ module RestClient
     SSLOptionList = %w{client_cert client_key ca_file ca_path cert_store
                        version ciphers verify_callback verify_callback_warnings}
 
+    DefaultOpenTimeout = Net::HTTP.new('127.0.0.1').open_timeout # depends on ruby version
+    DefaultReadTimeout = Net::HTTP.new('127.0.0.1').read_timeout
+
     def inspect
       "<RestClient::Request @method=#{@method.inspect}, @url=#{@url.inspect}>"
     end
@@ -85,6 +88,8 @@ module RestClient
       @user = args[:user] if args.include?(:user)
       @password = args[:password] if args.include?(:password)
 
+      @read_timeout = DefaultReadTimeout
+      @open_timeout = DefaultOpenTimeout
       if args.include?(:timeout)
         @read_timeout = args[:timeout]
         @open_timeout = args[:timeout]
@@ -691,20 +696,16 @@ module RestClient
         warn('Try passing :verify_ssl => false instead.')
       end
 
-      if defined? @read_timeout
-        if @read_timeout == -1
-          warn 'Deprecated: to disable timeouts, please use nil instead of -1'
-          @read_timeout = nil
-        end
-        net.read_timeout = @read_timeout
+      if @read_timeout == -1
+        warn 'Deprecated: to disable timeouts, please use nil instead of -1'
+        @read_timeout = nil
       end
-      if defined? @open_timeout
-        if @open_timeout == -1
-          warn 'Deprecated: to disable timeouts, please use nil instead of -1'
-          @open_timeout = nil
-        end
-        net.open_timeout = @open_timeout
+      net.read_timeout = @read_timeout
+      if @open_timeout == -1
+        warn 'Deprecated: to disable timeouts, please use nil instead of -1'
+        @open_timeout = nil
       end
+      net.open_timeout = @open_timeout
 
       RestClient.before_execution_procs.each do |before_proc|
         before_proc.call(req, args)

--- a/lib/restclient/resource.rb
+++ b/lib/restclient/resource.rb
@@ -20,6 +20,10 @@ module RestClient
   #
   #   RestClient::Resource.new('http://behindfirewall', :open_timeout => 10)
   #
+  # You can pass :timeout to set both open and read timeouts:
+  #
+  #   RestClient::Resource.new('http://behindfirewall', :timeout => 10)
+  #
   # You can also use resources to share common headers. For headers keys,
   # symbols are converted to strings. Example:
   #
@@ -120,11 +124,11 @@ module RestClient
     end
 
     def read_timeout
-      options[:read_timeout]
+      RestClient::Request.new(options.merge(:method => :get, :url => url)).read_timeout
     end
 
     def open_timeout
-      options[:open_timeout]
+      RestClient::Request.new(options.merge(:method => :get, :url => url)).open_timeout
     end
 
     def log

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -129,6 +129,39 @@ describe RestClient::Resource do
       resource = RestClient::Resource.new('www.example.com') { |response, request| 'foo' }
       expect(resource.get { |response, request| 'bar' }).to eq 'bar'
     end
+  end
 
+  describe 'open_timeout' do
+    it 'returns effective default when unset' do
+      resource = RestClient::Resource.new('x')
+      expect(resource.open_timeout).to eq RestClient::Request::DefaultOpenTimeout
+    end
+
+    it 'returns set value' do
+      resource = RestClient::Resource.new('x', open_timeout: 10)
+      expect(resource.open_timeout).to eq 10
+    end
+
+    it 'can be set via :timeout' do
+      resource = RestClient::Resource.new('x', timeout: 30)
+      expect(resource.open_timeout).to eq 30
+    end
+  end
+
+  describe 'read_timeout' do
+    it 'returns effective default when unset' do
+      resource = RestClient::Resource.new('x')
+      expect(resource.read_timeout).to eq RestClient::Request::DefaultReadTimeout
+    end
+
+    it 'returns set value' do
+      resource = RestClient::Resource.new('x', read_timeout: 120)
+      expect(resource.read_timeout).to eq 120
+    end
+
+    it 'can be set via :timeout' do
+      resource = RestClient::Resource.new('x', timeout: 30)
+      expect(resource.read_timeout).to eq 30
+    end
   end
 end


### PR DESCRIPTION
Fixes #591 — now the timeout accessors of both `Request` and `Resource` return the actual value, whether set explicitly, set via `:timeout`, or using Net::HTTP defaults.
They will only return `nil` when the timeout is actually infinite.
(Previously it was hard to know whether it's nil because unset, or because infinite.)

The main win IMHO is that this makes it easier to test other libraries that wrap RestClient ([real story][1]).
If a library allows setting timeouts (or not setting them!), you'd have to use stubs to test what parameters it passes to RestClient, and it was hard to be certain what is the resulting timeout.
Now it'll be possible to simply ask RestClient back and trust the answer.

Net::HTTP default open_timeout unfortunately depends on Ruby version (infinite up to 2.2, 60 seconds since 2.3.
To preserve existing default behavior on all ruby versions, I resorted to probing Net::HTTP's actual timeouts.  (Added a test that the probing returns nil/60 as expected per ruby version.)

**I haven't looked into other rubies defaults e.g. JRuby.  Please review carefully in that regard.**

[1]: https://github.com/abonas/kubeclient/pull/244#discussion_r113734722
