### PR TITLE
Fix up Payload generation to avoid nested payloads.

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -14,7 +14,10 @@ module RestClient
     extend self
 
     def generate(params)
-      if params.is_a?(String)
+      if params.is_a?(RestClient::Payload::Base)
+        # pass through Payload objects unchanged
+        params
+      elsif params.is_a?(String)
         Base.new(params)
       elsif params.is_a?(Hash)
         if params.delete(:multipart) == true || has_file?(params)
@@ -87,12 +90,20 @@ module RestClient
         @stream.close unless @stream.closed?
       end
 
+      def closed?
+        @stream.closed?
+      end
+
       def to_s_inspect
         to_s.inspect
       end
 
       def short_inspect
-        (size > 500 ? "#{size} byte(s) length" : to_s_inspect)
+        if size && size > 500
+          "#{size} byte(s) length"
+        else
+          to_s_inspect
+        end
       end
 
     end

--- a/spec/unit/payload_spec.rb
+++ b/spec/unit/payload_spec.rb
@@ -209,6 +209,14 @@ Content-Type: text/plain\r
         f.close
       end
     end
+
+    it "should have a closed? method" do
+      f = File.new(File.dirname(__FILE__) + "/master_shake.jpg")
+      payload = RestClient::Payload.generate(f)
+      expect(payload.closed?).to be_falsey
+      payload.close
+      expect(payload.closed?).to be_truthy
+    end
   end
 
   context "Payload generation" do
@@ -269,6 +277,19 @@ Content-Type: text/plain\r
     it "should handle non-multipart payload wrapped in ParamsArray" do
       params = RestClient::ParamsArray.new([[:arg, 'value1'], [:arg, 'value2']])
       expect(RestClient::Payload.generate(params)).to be_kind_of(RestClient::Payload::UrlEncoded)
+    end
+
+    it "should pass through Payload::Base and subclasses unchanged" do
+      payloads = [
+        RestClient::Payload::Base.new('foobar'),
+        RestClient::Payload::UrlEncoded.new({:foo => 'bar'}),
+        RestClient::Payload::Streamed.new(File.new(File.dirname(__FILE__) + "/master_shake.jpg")),
+        RestClient::Payload::Multipart.new({myfile: File.new(File.dirname(__FILE__) + "/master_shake.jpg")}),
+      ]
+
+      payloads.each do |payload|
+        expect(RestClient::Payload.generate(payload)).to equal(payload)
+      end
     end
   end
 end


### PR DESCRIPTION
- If Payload.generate() receives a Payload::Base or subclass, then
  return it as is rather than pointlessly wrapping it in a
  Payload::Streamed.
- Add a `.closed?` method to Payload::Base that wraps the underlying
  stream's `.closed?` method.
- Don't fail in `short_inspect` if `size` returns nil.