### PR TITLE
Encode resource url path

### DIFF
--- a/lib/restclient/resource.rb
+++ b/lib/restclient/resource.rb
@@ -166,8 +166,8 @@ module RestClient
     end
 
     def concat_urls(url, suburl) # :nodoc:
-      url = url.to_s
-      suburl = suburl.to_s
+      url = URI.encode(url.to_s)
+      suburl = URI.encode(suburl.to_s)
       if url.slice(-1, 1) == '/' or suburl.slice(0, 1) == '/'
         url + suburl
       else


### PR DESCRIPTION
I noticed that if I try to pass in path like "test test" into [ ] method, I was having errors since I didn't encode it beforehand. Would be great if it encodes by default!

Thanks for all the effort for this gem! It's a pleasure to work with. 


EDIT: tests are failing will fix this weekend