### PR TITLE
Add dependency on http-accept for Content-Type.

### DIFF
--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc', '>= 2.4.2', '< 6.0')
   s.add_development_dependency('rubocop', '~> 0')
 
+  s.add_dependency('http-accept', '>= 1.7.0', '< 2.0')
   s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
   s.add_dependency('mime-types', '>= 1.16', '< 4.0')
   s.add_dependency('netrc', '~> 0.8')

--- a/spec/unit/utils_spec.rb
+++ b/spec/unit/utils_spec.rb
@@ -34,11 +34,11 @@ describe RestClient::Utils do
   end
 
   describe '.cgi_parse_header' do
-    it 'parses headers' do
+    it 'parses headers', :unless => RUBY_VERSION.start_with?('2.0') do
       expect(RestClient::Utils.cgi_parse_header('text/plain')).
         to eq ['text/plain', {}]
 
-      expect(RestClient::Utils.cgi_parse_header('text/vnd.just.made.this.up ; ')).
+      expect(RestClient::Utils.cgi_parse_header('text/vnd.just.made.this.up')).
         to eq ['text/vnd.just.made.this.up', {}]
 
       expect(RestClient::Utils.cgi_parse_header('text/plain;charset=us-ascii')).
@@ -52,20 +52,20 @@ describe RestClient::Utils do
         to eq ['text/plain', {'charset' => 'us-ascii', 'another' => 'opt'}]
 
       expect(RestClient::Utils.cgi_parse_header(
-        'attachment; filename="silly.txt"')).
-        to eq ['attachment', {'filename' => 'silly.txt'}]
+        'foo/bar; filename="silly.txt"')).
+        to eq ['foo/bar', {'filename' => 'silly.txt'}]
 
       expect(RestClient::Utils.cgi_parse_header(
-        'attachment; filename="strange;name"')).
-        to eq ['attachment', {'filename' => 'strange;name'}]
+        'foo/bar; filename="strange;name"')).
+        to eq ['foo/bar', {'filename' => 'strange;name'}]
 
       expect(RestClient::Utils.cgi_parse_header(
-        'attachment; filename="strange;name";size=123;')).to eq \
-        ['attachment', {'filename' => 'strange;name', 'size' => '123'}]
+        'foo/bar; filename="strange;name";size=123')).to eq \
+        ['foo/bar', {'filename' => 'strange;name', 'size' => '123'}]
 
       expect(RestClient::Utils.cgi_parse_header(
-        'form-data; name="files"; filename="fo\\"o;bar"')).to eq \
-        ['form-data', {'name' => 'files', 'filename' => 'fo"o;bar'}]
+        'foo/bar; name="files"; filename="fo\\"o;bar"')).to eq \
+        ['foo/bar', {'name' => 'files', 'filename' => 'fo"o;bar'}]
     end
   end
 


### PR DESCRIPTION
The previous "Content-Type" header parser was ported from Python and was
not very idiomatic Ruby. While fast and correct per the RFCs, it was
triggering bugs in Ruby MRI that we could probably work around. Ideally
someone would fix the bugs in Ruby MRI, but I haven't had time to track
them down.

Switch to using HTTP::Accept for parsing the media-type charset out of
the "Content-Type" header. Also relax the tests since HTTP::Accept is
somewhat stricter in the input it will accept. As a result, rest-client
will now ignore Content-Type headers with a trailing `;` character.
(This is invalid per the RFCs, so impact is likely to be small in
comparison to fixing the Ruby 2.4 memory leak.)

I also tried using https://github.com/httprb/content_type.rb but it is
significantly slower (caused 2x blowup in time on a simple benchmark)
and doesn't correctly handle content-types containing '.' characters.

Fixes: #523 (occasional MRI segfault)
Fixes: #611 (MRI 2.4.* memory leak)

* Unfortunately, HTTP::Accept does not support Ruby 2.0 due to its use
  of named capture groups in StringScanner, which was added in Ruby 2.1.
  Because rest-client still supports Ruby 2.0, fall back on the old
  logic when running on Ruby 2.0. Even though Ruby 2.0 is unsupported,
  it probably still sees wide use since it is the system Ruby even on
  macOS Sierra.

* Don't bother running tests for .cgi_parse_header on Ruby 2.0. Still
  keep the higher level tests that will exercise the deprecated code.