### PR TITLE
Fix up rubocop and add to Travis build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg
 /rdoc
 /.yardoc
+/tmp

--- a/.rubocop
+++ b/.rubocop
@@ -1,0 +1,2 @@
+--display-cop-names
+--fail-level=W

--- a/.rubocop-disables.yml
+++ b/.rubocop-disables.yml
@@ -200,11 +200,10 @@ Style/Lambda:
 Layout/LeadingCommentSpace:
   Enabled: false
 
-# TODO
-# Offense count: 218
-# Configuration parameters: AllowURI.
 Metrics/LineLength:
-  Max: 340
+  Exclude:
+    - 'spec/**/*.rb'
+    - 'Rakefile'
 
 # TODO
 # Offense count: 28

--- a/.rubocop-disables.yml
+++ b/.rubocop-disables.yml
@@ -154,6 +154,9 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: false
+
 # Offense count: 31
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 Style/Encoding:

--- a/.rubocop-disables.yml
+++ b/.rubocop-disables.yml
@@ -110,10 +110,8 @@ Style/ConstantName:
 Metrics/CyclomaticComplexity:
   Max: 22
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/DeprecatedHashMethods:
-  Enabled: false
+Style/PreferredHashMethods:
+  EnforcedStyle: verbose
 
 # TODO: docs
 # Offense count: 17

--- a/.rubocop-disables.yml
+++ b/.rubocop-disables.yml
@@ -315,6 +315,9 @@ Layout/SpaceAroundOperators:
 Layout/SpaceBeforeBlockBraces:
   Enabled: false
 
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
 # Offense count: 37
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.

--- a/.rubocop-disables.yml
+++ b/.rubocop-disables.yml
@@ -17,7 +17,7 @@ Lint/StringConversionInInterpolation:
 Lint/UnusedBlockArgument:
   Enabled: false
 
-Lint/Eval:
+Security/Eval:
   Exclude:
   - rest-client.windows.gemspec
 
@@ -120,7 +120,7 @@ Style/Documentation:
 
 # Offense count: 9
 # Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
 
 # Offense count: 1
@@ -134,24 +134,24 @@ Style/EachWithObject:
 
 # Offense count: 5
 # Cop supports --auto-correct.
-Style/EmptyLines:
+Layout/EmptyLines:
   Enabled: false
 
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
 # Offense count: 1
 # Cop supports --auto-correct.
-Style/EmptyLinesAroundMethodBody:
+Layout/EmptyLinesAroundMethodBody:
   Enabled: false
 
 # Offense count: 9
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/EmptyLinesAroundModuleBody:
+Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 
 # Offense count: 31
@@ -186,7 +186,7 @@ Style/IfUnlessModifier:
 # Offense count: 6
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
 # NOTABUG
@@ -197,7 +197,7 @@ Style/Lambda:
 # TODO
 # Offense count: 14
 # Cop supports --auto-correct.
-Style/LeadingCommentSpace:
+Layout/LeadingCommentSpace:
   Enabled: false
 
 # TODO
@@ -296,47 +296,47 @@ Style/SignalException:
 # TODO
 # Offense count: 2
 # Cop supports --auto-correct.
-Style/SpaceAfterNot:
+Layout/SpaceAfterNot:
   Enabled: false
 
 # Offense count: 19
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/SpaceAroundEqualsInParameterDefault:
+Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: false
 
 # Offense count: 20
 # Cop supports --auto-correct.
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Enabled: false
 
 # Offense count: 9
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/SpaceBeforeBlockBraces:
+Layout/SpaceBeforeBlockBraces:
   Enabled: false
 
 # Offense count: 37
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
-Style/SpaceInsideBlockBraces:
+Layout/SpaceInsideBlockBraces:
   Enabled: false
 
 # Offense count: 6
 # Cop supports --auto-correct.
-Style/SpaceInsideBrackets:
+Layout/SpaceInsideBrackets:
   Enabled: false
 
 # Offense count: 181
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SupportedStyles.
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
 # TODO
 # Offense count: 9
 # Cop supports --auto-correct.
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Enabled: false
 
 # Offense count: 414

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
 ---
 inherit_from:
 - .rubocop-disables.yml
+
+AllCops:
+  Exclude:
+    - 'tmp/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,4 @@ inherit_from:
 AllCops:
   Exclude:
     - 'tmp/*.rb'
+    - 'vendor/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ rvm:
 cache: bundler
 
 script:
-  bundle exec rake test
+  - bundle exec rake test
+  - bundle exec rake rubocop
 
 branches:
   except:

--- a/Rakefile
+++ b/Rakefile
@@ -38,12 +38,11 @@ desc 'Regenerate authors file'
 task :authors do
   Dir.chdir(File.dirname(__FILE__)) do
     File.open('AUTHORS', 'w') do |f|
-      f.write( <<-EOM
+      f.write <<-EOM
 The Ruby REST Client would not be what it is today without the help of
 the following kind souls:
 
       EOM
-      )
     end
 
     sh 'git shortlog -s | cut -f 2 >> AUTHORS'
@@ -130,3 +129,12 @@ Rake::RDocTask.new do |t|
   t.rdoc_files.include('README.md')
   t.rdoc_files.include('lib/*.rb')
 end
+
+############################
+
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['--display-cop-names']
+end
+alias_task(:lint, :rubocop)

--- a/Rakefile
+++ b/Rakefile
@@ -70,8 +70,8 @@ namespace :all do
   task :build => ['ruby:build'] + \
     WindowsPlatforms.map {|p| "windows:#{p}:build"}
 
-  desc "Create tag v#{RestClient::VERSION} and for all platforms build and push " \
-    "rest-client #{RestClient::VERSION} to Rubygems"
+  desc "Create tag v#{RestClient::VERSION} and for all platforms build and " \
+    "push rest-client #{RestClient::VERSION} to Rubygems"
   task :release => ['build', 'ruby:release'] + \
     WindowsPlatforms.map {|p| "windows:#{p}:push"}
 

--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -148,7 +148,7 @@ module RestClient
   end
 
   # Compatibility
-  class ExceptionWithResponse < Exception
+  class ExceptionWithResponse < RestClient::Exception
   end
 
   # The request failed with an error code not managed by the code
@@ -228,14 +228,14 @@ module RestClient
   # The server broke the connection prior to the request completing.  Usually
   # this means it crashed, or sometimes that your network connection was
   # severed before it could complete.
-  class ServerBrokeConnection < Exception
+  class ServerBrokeConnection < RestClient::Exception
     def initialize(message = 'Server broke connection')
       super nil, nil
       self.message = message
     end
   end
 
-  class SSLCertificateNotVerified < Exception
+  class SSLCertificateNotVerified < RestClient::Exception
     def initialize(message = 'SSL certificate not verified')
       super nil, nil
       self.message = message


### PR DESCRIPTION
- Update rubocop configs to work again
- Fix a few rubocop warnings.
- Run rubocop as part of the Travis build.