### PR TITLE
Do not override valid headers closes #638

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -393,10 +393,15 @@ module RestClient
         # x-www-form-urlencoded but a Content-Type application/json was
         # also supplied by the user.
         payload_headers.each_pair do |key, val|
-          if headers.include?(key) && headers[key] != val
-            warn("warning: Overriding #{key.inspect} header " +
-                 "#{headers.fetch(key).inspect} with #{val.inspect} " +
-                 "due to payload")
+          if headers.include?(key)
+            # This is a valid header, do not override it from the payload
+            if headers[key].include?(val)
+              payload_headers.delete(key)
+            else
+              warn("warning: Overriding #{key.inspect} header " +
+                     "#{headers.fetch(key).inspect} with #{val.inspect} " +
+                     "due to payload")
+            end
           end
         end
 

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -263,6 +263,13 @@ describe RestClient::Request, :include_helpers do
     }).not_to match(/warning: Overriding "Content-Type" header/i)
   end
 
+  it "does not warn when overriding user header with header derived from payload if those header values were valid" do
+    expect(fake_stderr {
+      RestClient::Request.new(method: :post, url: 'example.com',
+                              payload: {'foo' => '123456'}, headers: { 'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8' })
+    }).not_to match(/warning: Overriding "Content-Type" header/i)
+  end
+
   it 'does not warn for a normal looking payload' do
     expect(fake_stderr {
       RestClient::Request.new(method: :post, url: 'example.com', payload: 'payload')


### PR DESCRIPTION
```
warning: Overriding "Content-Type" header "application/x-www-form-urlencoded; charset=UTF-8" with "application/x-www-form-urlencoded" due to payload
```

This change softens the override to allow valid Content-Type with additional fields e.g. specifying a charset. 

In my opinion, the rest-client should not have any overrides for user specified headers, but this is a compromise. I would be interested in the motivations here.

https://github.com/rest-client/rest-client/issues/638