### PR TITLE
PERF: Eliminate dependency on mime-types gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ updates.
 
 The rest-client gem depends on these other gems for usage at runtime:
 
-* [mime-types](http://rubygems.org/gems/mime-types)
+* [mini_mime](http://rubygems.org/gems/mini_mime)
 * [netrc](http://rubygems.org/gems/netrc)
 * [http-accept](https://rubygems.org/gems/http-accept)
 * [http-cookie](https://rubygems.org/gems/http-cookie)

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -1,13 +1,7 @@
 require 'tempfile'
 require 'securerandom'
 require 'stringio'
-
-begin
-  # Use mime/types/columnar if available, for reduced memory usage
-  require 'mime/types/columnar'
-rescue LoadError
-  require 'mime/types'
-end
+require 'mini_mime'
 
 module RestClient
   module Payload
@@ -194,8 +188,8 @@ module RestClient
       end
 
       def mime_for(path)
-        mime = MIME::Types.type_for path
-        mime.empty? ? 'text/plain' : mime[0].content_type
+        mime = MiniMime.lookup_by_filename path
+        mime ? mime.content_type : 'text/plain'
       end
 
       def boundary

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -2,13 +2,7 @@ require 'tempfile'
 require 'cgi'
 require 'netrc'
 require 'set'
-
-begin
-  # Use mime/types/columnar if available, for reduced memory usage
-  require 'mime/types/columnar'
-rescue LoadError
-  require 'mime/types'
-end
+require 'mini_mime'
 
 module RestClient
   # This class is used internally by RestClient to send the request, but you can also
@@ -864,12 +858,8 @@ module RestClient
         return ext
       end
 
-      types = MIME::Types.type_for(ext)
-      if types.empty?
-        ext
-      else
-        types.first.content_type
-      end
+      type = MiniMime.lookup_by_filename("a.#{ext}")
+      type ? type.content_type : ext
     end
   end
 end

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('http-accept', '>= 1.7.0', '< 2.0')
   s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
-  s.add_dependency('mime-types', '>= 1.16', '< 4.0')
+  s.add_dependency('mini_mime', '>= 0.1.1')
   s.add_dependency('netrc', '~> 0.8')
 
   s.required_ruby_version = '>= 2.0.0'


### PR DESCRIPTION
This PR is a rebase of #557 from @SamSaffron

---

The mime types gem (even with the magical columnar store by @jeremyevans) is a memory hog.

In particular on boot, mime/types/columnar will allocate **109k** objects and end up with a retained count of **31K** objects.

This bloat leaves objects that need to be marked and swept every major GC and bloats ruby processes.

To circumvent mini_mime was created.

It uses the exact same database as the full fledged mime types and is capable of only loading stuff on demand with a practical, safe and bound in-memory cache.

mini_mime will allocate **398** objects on boot and only retain **62** (due to rubygems inefficiency)

In table form:

boot allocations | boot retained | lookup | lookup uncached
-- | -- | -- | --
mini_mime | 398 | 62 | 641K/s | 33K/s
mime-types | 109796 | 31165 | 361K/s | 361K/s

The performance of mini_mime is pretty good, cached lookups are faster than the mime types gem and uncached lookups are 10x slower. (which is really not a huge issue considering the memory savings)