### PR TITLE
Add a timestamp to the RestClient log

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -537,6 +537,8 @@ module RestClient
 
       out = []
 
+      time = Time.zone.now
+      out << "# " << time.strftime("%Y-%m-%dT%H:%M:%S.") << "%06d" % time.usec
       out << "RestClient.#{method} #{redacted_url.inspect}"
       out << payload.short_inspect if payload
       out << processed_headers.to_a.sort.map { |(k, v)| [k.inspect, v.inspect].join("=>") }.join(", ")

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -535,8 +535,7 @@ module RestClient
     def log_request
       return unless log
 
-      time = Time.now
-      log << "# [" + time.strftime("%Y-%m-%dT%H:%M:%S.%6N %z".freeze)+ "]   Started request:"
+      log << "# [" + Time.now.strftime("%Y-%m-%dT%H:%M:%S.%6N %z".freeze)+ "]   Started request:"
 
       out = []
       out << "RestClient.#{method} #{redacted_url.inspect}"

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -536,7 +536,7 @@ module RestClient
       return unless log
 
       time = Time.zone.now
-      log << "# " + time.strftime("%Y-%m-%dT%H:%M:%S.") + "%06d" % time.usec
+      log << "# [" + time.strftime("%Y-%m-%dT%H:%M:%S.") + "%06d" % time.usec + "]   Started request:"
 
       out = []
       out << "RestClient.#{method} #{redacted_url.inspect}"

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -535,10 +535,10 @@ module RestClient
     def log_request
       return unless log
 
-      out = []
-
       time = Time.zone.now
-      out << "# " << time.strftime("%Y-%m-%dT%H:%M:%S.") << "%06d" % time.usec
+      log << "# " + time.strftime("%Y-%m-%dT%H:%M:%S.") + "%06d" % time.usec
+
+      out = []
       out << "RestClient.#{method} #{redacted_url.inspect}"
       out << payload.short_inspect if payload
       out << processed_headers.to_a.sort.map { |(k, v)| [k.inspect, v.inspect].join("=>") }.join(", ")

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -535,8 +535,8 @@ module RestClient
     def log_request
       return unless log
 
-      time = Time.zone.now
-      log << "# [" + time.strftime("%Y-%m-%dT%H:%M:%S.") + "%06d" % time.usec + "]   Started request:"
+      time = Time.now
+      log << "# [" + time.strftime("%Y-%m-%dT%H:%M:%S.%6N %z".freeze)+ "]   Started request:"
 
       out = []
       out << "RestClient.#{method} #{redacted_url.inspect}"

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -621,25 +621,25 @@ describe RestClient::Request, :include_helpers do
     it "logs a get request" do
       log = RestClient.log = []
       RestClient::Request.new(:method => :get, :url => 'http://url', :headers => {:user_agent => 'rest-client'}).log_request
-      expect(log[0]).to eq %Q{RestClient.get "http://url", "Accept"=>"*/*", "User-Agent"=>"rest-client"\n}
+      expect(log[1]).to eq %Q{RestClient.get "http://url", "Accept"=>"*/*", "User-Agent"=>"rest-client"\n}
     end
 
     it "logs a post request with a small payload" do
       log = RestClient.log = []
       RestClient::Request.new(:method => :post, :url => 'http://url', :payload => 'foo', :headers => {:user_agent => 'rest-client'}).log_request
-      expect(log[0]).to eq %Q{RestClient.post "http://url", "foo", "Accept"=>"*/*", "Content-Length"=>"3", "User-Agent"=>"rest-client"\n}
+      expect(log[1]).to eq %Q{RestClient.post "http://url", "foo", "Accept"=>"*/*", "Content-Length"=>"3", "User-Agent"=>"rest-client"\n}
     end
 
     it "logs a post request with a large payload" do
       log = RestClient.log = []
       RestClient::Request.new(:method => :post, :url => 'http://url', :payload => ('x' * 1000), :headers => {:user_agent => 'rest-client'}).log_request
-      expect(log[0]).to eq %Q{RestClient.post "http://url", 1000 byte(s) length, "Accept"=>"*/*", "Content-Length"=>"1000", "User-Agent"=>"rest-client"\n}
+      expect(log[1]).to eq %Q{RestClient.post "http://url", 1000 byte(s) length, "Accept"=>"*/*", "Content-Length"=>"1000", "User-Agent"=>"rest-client"\n}
     end
 
     it "logs input headers as a hash" do
       log = RestClient.log = []
       RestClient::Request.new(:method => :get, :url => 'http://url', :headers => { :accept => 'text/plain', :user_agent => 'rest-client' }).log_request
-      expect(log[0]).to eq %Q{RestClient.get "http://url", "Accept"=>"text/plain", "User-Agent"=>"rest-client"\n}
+      expect(log[1]).to eq %Q{RestClient.get "http://url", "Accept"=>"text/plain", "User-Agent"=>"rest-client"\n}
     end
 
     it "logs a response including the status code, content type, and result body size in bytes" do
@@ -672,7 +672,7 @@ describe RestClient::Request, :include_helpers do
     it 'does not log request password' do
       log = RestClient.log = []
       RestClient::Request.new(:method => :get, :url => 'http://user:password@url', :headers => {:user_agent => 'rest-client'}).log_request
-      expect(log[0]).to eq %Q{RestClient.get "http://user:REDACTED@url", "Accept"=>"*/*", "User-Agent"=>"rest-client"\n}
+      expect(log[1]).to eq %Q{RestClient.get "http://user:REDACTED@url", "Accept"=>"*/*", "User-Agent"=>"rest-client"\n}
     end
 
     it 'logs to a passed logger, if provided' do


### PR DESCRIPTION
Add a timestamp to the RestClient log, and use the same time format that the Ruby logger use, so that it is easier to compare the restclient log with the Rails server log (in case you use Rails). 

Note: Uses Time.now and not Time.zone.now, since RestClient may be used without Rails.