### PR TITLE
Fix stringify_headers so it can handle hyphenated symbols

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -553,7 +553,7 @@ module RestClient
     def stringify_headers headers
       headers.inject({}) do |result, (key, value)|
         if key.is_a? Symbol
-          key = key.to_s.split(/_/).map(&:capitalize).join('-')
+          key = key.to_s.split(/[_-]/).map(&:capitalize).join('-')
         end
         if 'CONTENT-TYPE' == key.upcase
           result[key] = maybe_convert_extension(value.to_s)

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -323,6 +323,13 @@ describe RestClient::Request, :include_helpers do
       expect(headers['Content-Type']).to eq 'abc'
     end
 
+    it "converts header symbols from :'content-type' to 'Content-Type'" do
+      expect(@request).to receive(:default_headers).and_return({})
+      headers = @request.make_headers(:'content-type' => 'abc')
+      expect(headers).to have_key('Content-Type')
+      expect(headers['Content-Type']).to eq 'abc'
+    end
+
     it "converts content-type from extension to real content-type" do
       expect(@request).to receive(:default_headers).and_return({})
       headers = @request.make_headers(:content_type => 'json')


### PR DESCRIPTION
`stringify_headers` incorrectly assumed symbolized header keys only use underscores for separating words. However, symbols may also contain hyphens for that purpose. E.g. `{'Content-Type': 'application/json'}` has to be treated the same way as `{:content_type => 'application/json'}`.