### PR TITLE
When creating a Tempfile for a raw response, preserve the file extension

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -728,7 +728,8 @@ module RestClient
           res = net_http_do_request(http, req, payload) { |http_response|
             if @raw_response
               # fetch body into tempfile
-              tempfile = fetch_body_to_tempfile(http_response)
+              file_extension = File.extname(@uri.path)
+              tempfile = fetch_body_to_tempfile(http_response, file_extension)
             else
               # fetch body
               http_response.read_body
@@ -780,11 +781,11 @@ module RestClient
       end
     end
 
-    def fetch_body_to_tempfile(http_response)
+    def fetch_body_to_tempfile(http_response, file_extension)
       # Taken from Chef, which as in turn...
       # Stolen from http://www.ruby-forum.com/topic/166423
       # Kudos to _why!
-      tf = Tempfile.new('rest-client.')
+      tf = Tempfile.new(['rest-client', file_extension])
       tf.binmode
 
       size = 0

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -1144,17 +1144,21 @@ describe RestClient::Request, :include_helpers do
 
   describe "raw response" do
     it "should read the response into a binary-mode tempfile" do
-      @request = RestClient::Request.new(:method => "get", :url => "example.com", :raw_response => true)
+      @request = RestClient::Request.new(
+        :method => "get",
+        :url => "example.com/example.pdf?foo=bar",
+        :raw_response => true
+      )
 
       tempfile = double("tempfile")
       expect(tempfile).to receive(:binmode)
       allow(tempfile).to receive(:open)
       allow(tempfile).to receive(:close)
-      expect(Tempfile).to receive(:new).with("rest-client.").and_return(tempfile)
+      expect(Tempfile).to receive(:new).with(["rest-client", ".pdf"]).and_return(tempfile)
 
       net_http_res = Net::HTTPOK.new(nil, "200", "body")
       allow(net_http_res).to receive(:read_body).and_return("body")
-      received_tempfile = @request.send(:fetch_body_to_tempfile, net_http_res)
+      received_tempfile = @request.send(:fetch_body_to_tempfile, net_http_res, ".pdf")
       expect(received_tempfile).to eq tempfile
     end
   end


### PR DESCRIPTION
When passing `raw_response: true` into `RestClient::Request.execute`, a `RestClient::RawResponse` is returned (instead of a `Response`) which provides access to a `Tempfile` containing the response body via its `#file` method. This is useful if, for example, you expect a binary response from the server.

At the moment, the `Tempfile` is created with a generic name (`rest-client.` followed by some random characters introduced by `Tempfile` itself). But this is quite annoying as it can be useful particularly to hold on to the original file extension (for example, even `rest-client` [itself][1] uses the path of a provided file to determine its `Content-Type` when performing a file upload).

This tweaks the behaviour so that the `Tempfile` is created with the same extension as was in the original URL.

[1]: https://github.com/rest-client/rest-client/blob/master/lib/restclient/payload.rb#L186