### PR TITLE
Decode a URL encoded proxy username or password

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -450,8 +450,10 @@ module RestClient
         # proxy explicitly set to none
         Net::HTTP.new(hostname, port, nil, nil, nil, nil)
       else
+        pass = p_uri.password ? CGI.unescape(p_uri.password) : nil
+        user = p_uri.user     ? CGI.unescape(p_uri.user)     : nil
         Net::HTTP.new(hostname, port,
-                      p_uri.hostname, p_uri.port, p_uri.user, p_uri.password)
+                      p_uri.hostname, p_uri.port, user, pass)
 
       end
     end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -555,6 +555,18 @@ describe RestClient::Request, :include_helpers do
       expect(@proxy_req.net_http_object('host', 80).proxy_address).to eq('::1')
     end
 
+    it "decodes an encoded username in a proxy URL" do
+      allow(RestClient).to receive(:proxy).and_return("http://%24myuser:xxxx@myproxy.example.com:3128")
+      allow(RestClient).to receive(:proxy_set?).and_return(true)
+      expect(@proxy_req.net_http_object('host', 80).proxy_user).to eq("$myuser")
+    end
+
+    it "decodes an encoded password in a proxy URL" do
+      allow(RestClient).to receive(:proxy).and_return("http://myuser:%24%3Fpass@myproxy.example.com:3128")
+      allow(RestClient).to receive(:proxy_set?).and_return(true)
+      expect(@proxy_req.net_http_object('host', 80).proxy_pass).to eq("$?pass")
+    end
+
     it "creates a non-proxy class if a proxy url is not given" do
       expect(@proxy_req.net_http_object('host', 80).proxy?).to be_falsey
     end


### PR DESCRIPTION
Fixes #661

We already decode a URL encoded username or password using CGI.unescape,
this change does the same thing for a proxy's credentials provided in a
URL.