### PR TITLE
Don't warn on Content-Type boundary change

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -394,6 +394,9 @@ module RestClient
         # also supplied by the user.
         payload_headers.each_pair do |key, val|
           if headers.include?(key) && headers[key] != val
+            # Don't warn, when the only change is adding boundary,
+            # which happens with multipart requests
+            next if key == 'Content-Type' && val.include?('boundary') && val.include?(headers[key])
             warn("warning: Overriding #{key.inspect} header " +
                  "#{headers.fetch(key).inspect} with #{val.inspect} " +
                  "due to payload")


### PR DESCRIPTION
When sending multipart payload while setting the 'Content-Type' header,
rest-client complains about the headers changing:

    warning: Overriding "Content-Type" header "multipart/form-data"
    with "multipart/form-data; boundary=----RubyFormBoundaryueJ8T7XEKh2BLjan"
    due to payload

Since we're actually not changing the 'Content-Type' but rather just
extending it, we should not produce this warnings in this case.