### PR TITLE
Updates to `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingComm…

### DIFF
--- a/.rubocop-disables.yml
+++ b/.rubocop-disables.yml
@@ -350,7 +350,9 @@ Layout/SpaceInsideParens:
 Style/StringLiterals:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 Style/TrailingCommaInArguments:
   Enabled: false


### PR DESCRIPTION
…aInHashLiteral`

```
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in vendor/bundle/ruby/2.4.0/gems/rest-client-2.0.2/.rubocop-disables.yml, please update it)
```