### PR TITLE
Allow to configure user agent globally

### DIFF
--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -90,6 +90,16 @@ module RestClient
     Request.execute(:method => :options, :url => url, :headers => headers, &block)
   end
 
+  # Configure a custom user agent for all requests. This can be overridden on a
+  # per-request basis by passing `:user_agent` in the request's header.
+  def self.user_agent
+    @user_agent ||= Platform.default_user_agent
+  end
+
+  def self.user_agent=(value)
+    @user_agent = value
+  end
+
   # A global proxy URL to use for all requests. This can be overridden on a
   # per-request basis by passing `:proxy` to RestClient::Request.
   def self.proxy

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -581,7 +581,7 @@ module RestClient
     def default_headers
       {
         :accept => '*/*',
-        :user_agent => RestClient::Platform.default_user_agent,
+        :user_agent => RestClient.user_agent,
       }
     end
 

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -618,6 +618,22 @@ describe RestClient::Request, :include_helpers do
 
 
   describe "logging" do
+    it "logs custom user agent" do
+      log = RestClient.log = []
+      RestClient.user_agent = "Foo"
+      RestClient::Request.new(:method => :get, :url => 'http://url').log_request
+      RestClient.user_agent = nil
+      expect(log[0]).to eq %Q{RestClient.get "http://url", "Accept"=>"*/*", "User-Agent"=>"Foo"\n}
+    end
+
+    it "logs custom user agent overwritten by headers" do
+      log = RestClient.log = []
+      RestClient.user_agent = "Foo"
+      RestClient::Request.new(:method => :get, :url => 'http://url', :headers => {:user_agent => 'Bar'}).log_request
+      RestClient.user_agent = nil
+      expect(log[0]).to eq %Q{RestClient.get "http://url", "Accept"=>"*/*", "User-Agent"=>"Bar"\n}
+    end
+
     it "logs a get request" do
       log = RestClient.log = []
       RestClient::Request.new(:method => :get, :url => 'http://url', :headers => {:user_agent => 'rest-client'}).log_request


### PR DESCRIPTION
  `RestClient.user_agent=` sets a custom user agent to all requests
  that doesn't overwrite via headers.

This is useful when we want to have a custom user agent to be set across all requests that are made via RestClient without having to set it up via the request's header.

In my use case, one solution that I did was to monkey patch `RestClient::Platform.default_user_agent` - however would be nice to allow user agent to be easily customisable instead.