### PR TITLE
Update Rubocop cop names

### DIFF
--- a/.rubocop-disables.yml
+++ b/.rubocop-disables.yml
@@ -8,7 +8,7 @@
 # TODO
 # Offense count: 1
 # Cop supports --auto-correct.
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: false
 
 # Tests only
@@ -21,7 +21,7 @@ Security/Eval:
   Exclude:
   - rest-client.windows.gemspec
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
   - lib/restclient/utils.rb
 
@@ -184,7 +184,7 @@ Style/HashSyntax:
 Style/IfUnlessModifier:
   Enabled: false
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Exclude:
     - 'spec/**/*.rb'
 
@@ -199,7 +199,7 @@ Style/Lambda:
 Layout/LeadingCommentSpace:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Exclude:
     - 'spec/**/*.rb'
     - 'Rakefile'
@@ -364,7 +364,7 @@ Style/UnlessElse:
 # TODO?
 # Offense count: 6
 # Cop supports --auto-correct.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: false
 
 # Offense count: 5


### PR DESCRIPTION
Fixes outdated Rubocop cop names:
```
$ bundle exec rake rubocop
Running RuboCop...
.rubocop-disables.yml: Metrics/LineLength has the wrong namespace - should be Layout
Error: The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in .rubocop-disables.yml, please update it)
The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in .rubocop-disables.yml, please update it)
The `Lint/StringConversionInInterpolation` cop has been renamed to `Lint/RedundantStringCoercion`.
(obsolete configuration found in .rubocop-disables.yml, please update it)
The `Style/UnneededPercentQ` cop has been renamed to `Style/RedundantPercentQ`.
(obsolete configuration found in .rubocop-disables.yml, please update it)
RuboCop failed!
The command "bundle exec rake rubocop" exited with 1.
```