### PR TITLE
Add option to specify file extension for raw_response

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -102,6 +102,7 @@ module RestClient
       end
       @block_response = args[:block_response]
       @raw_response = args[:raw_response] || false
+      @raw_response_extension = args[:raw_response_extension]
 
       @stream_log_percent = args[:stream_log_percent] || 10
       if @stream_log_percent <= 0 || @stream_log_percent > 100
@@ -789,7 +790,7 @@ module RestClient
       # Taken from Chef, which as in turn...
       # Stolen from http://www.ruby-forum.com/topic/166423
       # Kudos to _why!
-      tf = Tempfile.new('rest-client.')
+      tf = Tempfile.new(['rest-client.', @raw_response_extension].compact)
       tf.binmode
 
       size = 0


### PR DESCRIPTION
My colleagues and I desired this functionality, as we have a scenario where it is necessary to ensure the file we get with raw_response is named with a ".pdf" extension. There are plenty of work-arounds, but most involve some overhead (using block_response or copying the tempfile into a new file) that can be avoided by providing the extension at the time of calling `Tempfile.new`. I considered using the raw_response parameter itself, allowing a string, and using it as the extension if provided, eg:
```ruby
RestClient::Request.new(:method => "get", :url => "example.com", :raw_response => '.pdf')
```
But the approach used here instead should guarantee backwards compatibility, at the cost of just one additional instance variable:
```ruby
@request = RestClient::Request.new(method: :get, url: 'example.com', raw_response: true, raw_response_extension: '.pdf')
```

One other choice would be to allow passing the entire filename parameter, rather than just the extension. I am not sure if there is much use for it, but it would be easy enough to do:
```ruby
# in initialize
@raw_response_filename = args[:raw_response_filename] || 'rest-client.'

# in fetch_body_to_tempfile
Tempfile.new(@raw_response_filename)
```

If you have any preference for a different approach, please let me know and I would be happy to make any needed adjustments. 