### PR TITLE
Add `write_timeout` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,18 +794,18 @@ RestClient.delete 'http://example.com/resource', {:Authorization => 'Bearer cT0f
 
 By default the timeout for a request is 60 seconds. Timeouts for your request can
 be adjusted by setting the `timeout:` to the number of seconds that you would like
-the request to wait. Setting `timeout:` will override both `read_timeout:` and `open_timeout:`.
+the request to wait. Setting `timeout:` will override `read_timeout:`, `open_timeout:` and `write_timeout:`.
 
 ```ruby
 RestClient::Request.execute(method: :get, url: 'http://example.com/resource',
                             timeout: 120)
 ```
 
-Additionally, you can set `read_timeout:` and `open_timeout:` separately.
+Additionally, you can set `read_timeout:`, `open_timeout:` and `write_timeout:` separately.
 
 ```ruby
 RestClient::Request.execute(method: :get, url: 'http://example.com/resource',
-                            read_timeout: 120, open_timeout: 240)
+                            read_timeout: 120, open_timeout: 240, write_timeout: 480)
 ```
 
 ## Cookies

--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -222,6 +222,14 @@ module RestClient
         'Timed out reading data from server'
       end
     end
+
+    # Timeout when writting to a server. Typically wraps Net::WriteTimeout (in
+    # ruby 2.6 or greater).
+    class WriteTimeout < Timeout
+      def default_message
+        'Timed out writting data to server'
+      end
+    end
   end
 
 


### PR DESCRIPTION
This commit adds support to configure `Net::HTTP#write_timeout=` using
both `timeout` and `write_timeout` options.

For more information about `Net::HTTP#write_timeout=` check the
following links:
* https://bugs.ruby-lang.org/issues/13396
* https://ruby-doc.org/stdlib-2.6/libdoc/net/http/rdoc/Net/HTTP.html#attribute-i-write_timeout