### PR TITLE
fix rubocop config

### DIFF
--- a/.rubocop-disables.yml
+++ b/.rubocop-disables.yml
@@ -8,7 +8,7 @@
 # TODO
 # Offense count: 1
 # Cop supports --auto-correct.
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: false
 
 # Tests only
@@ -21,7 +21,7 @@ Security/Eval:
   Exclude:
   - rest-client.windows.gemspec
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
   - lib/restclient/utils.rb
 
@@ -44,12 +44,6 @@ Style/AndOr:
 # Offense count: 3
 # Cop supports --auto-correct.
 Style/BlockDelimiters:
-  Enabled: false
-
-# Offense count: 48
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/BracesAroundHashParameters:
   Enabled: false
 
 # Offense count: 1
@@ -184,7 +178,7 @@ Style/HashSyntax:
 Style/IfUnlessModifier:
   Enabled: false
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Exclude:
     - 'spec/**/*.rb'
 
@@ -364,7 +358,7 @@ Style/UnlessElse:
 # TODO?
 # Offense count: 6
 # Cop supports --auto-correct.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: false
 
 # Offense count: 5


### PR DESCRIPTION
There are some rubocop complaints about the outdated config:
```
.rubocop-disables.yml: Metrics/LineLength has the wrong namespace - should be Layout
222Error: The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation`.
223(obsolete configuration found in .rubocop-disables.yml, please update it)
224The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
225(obsolete configuration found in .rubocop-disables.yml, please update it)
226The `Lint/StringConversionInInterpolation` cop has been renamed to `Lint/RedundantStringCoercion`.
227(obsolete configuration found in .rubocop-disables.yml, please update it)
228The `Style/UnneededPercentQ` cop has been renamed to `Style/RedundantPercentQ`.
229(obsolete configuration found in .rubocop-disables.yml, please update it)
230The `Style/BracesAroundHashParameters` cop has been removed.
231(obsolete configuration found in .rubocop-disables.yml, please update it)
232RuboCop failed!
```

This PR fixes it.