### PR TITLE
Add ipaddr

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -54,7 +54,7 @@ module RestClient
     attr_reader :method, :uri, :url, :headers, :payload, :proxy,
                 :user, :password, :read_timeout, :max_redirects,
                 :open_timeout, :raw_response, :processed_headers, :args,
-                :ssl_opts
+                :ssl_opts, :ipaddr
 
     # An array of previous redirection responses
     attr_accessor :redirection_history
@@ -146,6 +146,10 @@ module RestClient
         if !ssl_ca_file && !ssl_ca_path && !@ssl_opts.include?(:cert_store)
           @ssl_opts[:cert_store] = self.class.default_ssl_cert_store
         end
+      end
+
+      if args.include?(:ipaddr)
+        @ipaddr = args[:ipaddr]
       end
 
       @log = args[:log]
@@ -669,6 +673,8 @@ module RestClient
       net.ca_file = ssl_ca_file if ssl_ca_file
       net.ca_path = ssl_ca_path if ssl_ca_path
       net.cert_store = ssl_cert_store if ssl_cert_store
+
+      net.ipaddr = ipaddr if ipaddr
 
       # We no longer rely on net.verify_callback for the main SSL verification
       # because it's not well supported on all platforms (see comments below).


### PR DESCRIPTION
Net::HTTP has a setter for ipaddr https://github.com/ruby/ruby/blob/ruby_2_7/lib/net/http.rb#L738
Restclient however doesn't expose this attribute to developers.

When the ipaddr attribute is set Net::HTTP uses it to establish the actual TCP socket, the regular address is used to maintain SNI compatibility and SSL hostname validation.

There are a couple of reasons why a developer might want to use the ipaddr parameter to bypass the dns lookup: 
- Ensure that a particular hostname is resolved to a given ip adress. And not some malicious other ip adress, usefull when a bad actor is in control of a domains dns records.
- To single out DNS issues in debug scenario's.
- Performance reasons, to prevent lookups with low cache ttl's in high load cases. (Not recommended as it ignores DNS standards)

Please let me know if this is something you're looking to support, I'm willing to write the specs and update the docs if it has a chance of being merged.