### PR TITLE
Support fat binary Windows on Ruby 3.1 (x64-mingw-ucrt)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ alias_task(:test, :spec)
 
 ############################
 
-WindowsPlatforms = %w{x86-mingw32 x64-mingw32 x86-mswin32}
+WindowsPlatforms = %w{x86-mingw32 x64-mingw32 x64-mingw-ucrt x86-mswin32}
 
 namespace :all do
 


### PR DESCRIPTION
As of Ruby 3.1, the Ruby Windows Installer is now releasing its platform as x64-mingw-ucrt. Refer to https://github.com/ruby/setup-ruby/issues/193

Compare Ruby 3.0 vs. 3.1 on Windows:

```
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x64-mingw32]
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x64-mingw-ucrt]
```

This patch adds x64-mingw-ucrt to the cross-compilation, so that a fat binary will be created for x64-mingw-ucrt platform.