### PR TITLE
Upgrading to the latest version of http-accept

### DIFF
--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc', '>= 2.4.2', '< 6.0')
   s.add_development_dependency('rubocop', '~> 0.49')
 
-  s.add_dependency('http-accept', '>= 1.7.0', '< 2.0')
+  s.add_dependency('http-accept', '>= 1.7.0', '< 3.0')
   s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
   s.add_dependency('mime-types', '>= 1.16', '< 4.0')
   s.add_dependency('netrc', '~> 0.8')


### PR DESCRIPTION
The v2 strain of `http-accept` still works perfectly fine with `rest-client` as is.

This PR relaxes the constraints in the gemspec, to make it possible e.g. to upgrade to `http-accept` v 2.2.0.

Please let me know how I can help to get this merged and released asap.