### PR TITLE
Don't require file in multipart request to have a path

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -158,7 +158,7 @@ module RestClient
         last_index = x.length - 1
         x.each_with_index do |a, index|
           k, v = * a
-          if v.respond_to?(:read) && v.respond_to?(:path)
+          if v.respond_to?(:read) && (v.respond_to?(:original_filename) || v.respond_to?(:path))
             create_file_field(@stream, k, v)
           else
             create_regular_field(@stream, k, v)
@@ -180,10 +180,11 @@ module RestClient
 
       def create_file_field(s, k, v)
         begin
+          filename = v.respond_to?(:original_filename) = v.original_filename : File.basename(v.path)
           s.write("Content-Disposition: form-data;")
           s.write(" name=\"#{k}\";") unless (k.nil? || k=='')
-          s.write(" filename=\"#{v.respond_to?(:original_filename) ? v.original_filename : File.basename(v.path)}\"#{EOL}")
-          s.write("Content-Type: #{v.respond_to?(:content_type) ? v.content_type : mime_for(v.path)}#{EOL}")
+          s.write(" filename=\"#{filename}\"#{EOL}")
+          s.write("Content-Type: #{v.respond_to?(:content_type) ? v.content_type : mime_for(filename)}#{EOL}")
           s.write(EOL)
           while (data = v.read(8124))
             s.write(data)


### PR DESCRIPTION
The path isn't required to stream the file. However, prior to this PR an object that doesn't respond to `path` gets treated as a regular field. 

In a project I am using Shrine, which has a class Shrine::UploadedFile. This implements most of the file API, but since it doesn't necessarily represent a file on the server but a file somewhere else (e.g. AWS S3) it doesn't implement path. It does however implement `read`, which is enough for the file to be streamed in a RestClient post request.