### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ extract and set headers for them as needed:
 ```ruby
 response = RestClient.get 'http://example.com/action_which_sets_session_id'
 response.cookies
-# => {"_applicatioN_session_id" => "1234"}
+# => {"_application_session_id" => "1234"}
 
 response2 = RestClient.post(
   'http://localhost:3000/',

--- a/history.md
+++ b/history.md
@@ -312,7 +312,7 @@ release:
 
 # 1.5.0
 
-- the response is now a String with the Response module a.k.a. the change in 1.4.0 was a mistake (Response.body is returning self for compatability)
+- the response is now a String with the Response module a.k.a. the change in 1.4.0 was a mistake (Response.body is returning self for compatibility)
 - added AbstractResponse.to_i to improve semantic
 - multipart Payloads ignores the name attribute if it's not set (patch provided by Tekin Suleyman)
 - correctly takes into account user headers whose keys are strings (path provided by Cyril Rohr)
@@ -328,7 +328,7 @@ release:
 
 # 1.4.1
 
-- fixed parameters managment when using hash
+- fixed parameters management when using hash
 
 # 1.4.0
 
@@ -351,7 +351,7 @@ The response change may be breaking in rare cases.
 - cleaner log API, add a warning for some cases but should be compatible
 - accept multiple "Set-Cookie" headers, see http://www.ietf.org/rfc/rfc2109.txt (patch provided by Cyril Rohr)
 - remove "Content-Length" and "Content-Type" headers when following a redirection (patch provided by haarts)
-- all http error codes have now a corresponding exception class and all of them contain the Reponse -> this means that the raised exception can be different
+- all http error codes have now a corresponding exception class and all of them contain the Response -> this means that the raised exception can be different
 - changed "Content-Disposition: multipart/form-data" to "Content-Disposition: form-data" per RFC 2388 (patch provided by Kyle Crawford)
 
 The only breaking change should be the exception classes, but as the new classes inherits from the existing ones, the breaking cases should be rare.
@@ -360,7 +360,7 @@ The only breaking change should be the exception classes, but as the new classes
 
 - formatting changed from tabs to spaces
 - logged requests now include generated headers
-- accept and content-type headers can now be specified using extentions: RestClient.post "http://example.com/resource", { 'x' => 1 }.to_json, :content_type => :json, :accept => :json
+- accept and content-type headers can now be specified using extensions: RestClient.post "http://example.com/resource", { 'x' => 1 }.to_json, :content_type => :json, :accept => :json
 - should be 1.1.1 but renamed to 1.2.0 because 1.1.X versions has already been packaged on Debian
 
 # 1.1.0
@@ -372,6 +372,6 @@ The only breaking change should be the exception classes, but as the new classes
 - the mime-type code now rely on the mime-types gem http://mime-types.rubyforge.org/ instead of an internal partial list
 - 204 response returns a Response instead of nil (patch provided by Elliott Draper)
 
-All changes exept the last one should be fully compatible with the previous version.
+All changes except the last one should be fully compatible with the previous version.
 
 NOTE: due to a dependency problem and to the last change, heroku users should update their heroku gem to >= 1.5.3 to be able to use this version.

--- a/lib/rest_client.rb
+++ b/lib/rest_client.rb
@@ -1,2 +1,2 @@
-# This file exists for backward compatbility with require 'rest_client'
+# This file exists for backward compatibility with require 'rest_client'
 require File.dirname(__FILE__) + '/restclient'

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -492,7 +492,7 @@ module RestClient
     # Return a certificate store that can be used to validate certificates with
     # the system certificate authorities. This will probably not do anything on
     # OS X, which monkey patches OpenSSL in terrible ways to insert its own
-    # validation. On most *nix platforms, this will add the system certifcates
+    # validation. On most *nix platforms, this will add the system certificates
     # using OpenSSL::X509::Store#set_default_paths. On Windows, this will use
     # RestClient::Windows::RootCerts to look up the CAs trusted by the system.
     #

--- a/spec/integration/httpbin_spec.rb
+++ b/spec/integration/httpbin_spec.rb
@@ -115,7 +115,7 @@ describe RestClient::Request do
       expect(parsed['method']).to eq 'GET'
       expect(parsed.fetch('gzipped')).to be true
 
-      # == delate ==
+      # == deflate ==
       raw = execute_httpbin('deflate', method: :get, headers: {accept_encoding: 'gzip, deflate'})
 
       decoded = Zlib::Inflate.new.inflate(raw.body)

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -85,7 +85,7 @@ describe RestClient::Resource do
     expect(parent['posts'].block).to eq block
   end
 
-  it "the block should be overrideable" do
+  it "the block should be overridable" do
     block1 = proc {|r| r}
     block2 = proc {|r| }
     parent = RestClient::Resource.new('http://example.com', &block1)
@@ -96,7 +96,7 @@ describe RestClient::Resource do
 
   # Test fails on jruby 9.1.[0-5].* due to
   # https://github.com/jruby/jruby/issues/4217
-  it "the block should be overrideable in ruby 1.9 syntax",
+  it "the block should be overridable in ruby 1.9 syntax",
       :unless => (RUBY_ENGINE == 'jruby' && JRUBY_VERSION =~ /\A9\.1\.[0-5]\./) \
   do
     block1 = proc {|r| r}


### PR DESCRIPTION
Found via `codespell -L anull,fo`